### PR TITLE
use parent classLoader if custom classLoader is undefined

### DIFF
--- a/org.coreasm.engine/src/org/coreasm/engine/Engine.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/Engine.java
@@ -784,8 +784,9 @@ public class Engine implements ControlAPI {
 	 */
 	private void loadPlugin(String pName, String className, URL... urls) throws EngineException {
 		URLClassLoader loader = null;
+
 		if (this.classLoader == null)
-			loader = new URLClassLoader(urls);
+			loader = new URLClassLoader(urls, getClass().getClassLoader());
 		else
 			loader = new URLClassLoader(urls, this.classLoader);
 


### PR DESCRIPTION
I had a NoClassDefFoundError exception when I tried to run the compiler via `mvn exec:java -Dexec.mainClass="org.coreasm.compiler.Main"`

The answer suggested here solved it: https://stackoverflow.com/a/23133504/2565743