### PR TITLE
add enginePath and runtimeDirectory to CommandLineParser

### DIFF
--- a/org.coreasm.engine/src/org/coreasm/compiler/CommandLineParser.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/CommandLineParser.java
@@ -118,6 +118,14 @@ public class CommandLineParser {
 					options.keepTempFiles = Boolean.parseBoolean(args[i + 1]);
 					i++;
 				}
+				else if(args[i].equals("-enginePath")){
+					options.enginePath = args[i + 1];
+					i++;
+				}
+				else if(args[i].equals("-runtimeDirectory")){
+					options.runtimeDirectory = args[i + 1];
+					i++;
+				}
 				else{
 					throw new CommandLineException("Unknown command line option: " + args[i]);
 				}


### PR DESCRIPTION
When running the compiler from the console the `enginePath` option remains `null` and `runtimeDirectory` remains the provided hard-coded path
