### PR TITLE
use File instead of String

### DIFF
--- a/org.coreasm.engine/src/org/coreasm/compiler/CoreASMCompiler.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/CoreASMCompiler.java
@@ -170,8 +170,8 @@ public class CoreASMCompiler implements CompilerEngine {
 				if(!f.delete()) CoreASMCompiler.getEngine().getLogger().warn(CoreASMCompiler.class, "Could not delete file " + f.getAbsolutePath());
 			}
 			else{
-				for(String s : f.list()){
-					purgeDir(new File(f.getAbsolutePath() + "\\" + s));
+				for(File d : f.listFiles()){
+					purgeDir(d);
 				}
 				if(!f.delete()) CoreASMCompiler.getEngine().getLogger().warn(CoreASMCompiler.class, "Could not delete directory " + f.getAbsolutePath());
 			}
@@ -436,7 +436,7 @@ public class CoreASMCompiler implements CompilerEngine {
 	
 	private void compileSources(CompilerInformation info) throws CompilerException{
 		CoreASMCompiler.getEngine().getLogger().debug(CoreASMCompiler.class, "code generation complete, dumping source files to " + options.tempDirectory);
-		ArrayList<String> classes = null;
+		ArrayList<File> classes = null;
 		try {
 			classes = classLibrary.dumpClasses();
 		} catch (LibraryEntryException e) {

--- a/org.coreasm.engine/src/org/coreasm/compiler/JavaCompilerWrapper.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/JavaCompilerWrapper.java
@@ -1,5 +1,6 @@
 package org.coreasm.compiler;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 
@@ -29,7 +30,7 @@ public class JavaCompilerWrapper {
 	 * @param classes A list of classes which need to be compiled
 	 * @throws CompilerException If an error occured during the compilation process
 	 */
-	public static void compile(CompilerOptions options, ArrayList<String> classes) throws CompilerException{
+	public static void compile(CompilerOptions options, ArrayList<File> classes) throws CompilerException{
 		JavaCompiler jc = ToolProvider.getSystemJavaCompiler();
 		if(jc == null){
 			CoreASMCompiler.getEngine().addError("java compiler not found");
@@ -41,7 +42,7 @@ public class JavaCompilerWrapper {
 		DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<JavaFileObject>();
 		//set up a file manager to provide java sources
 		StandardJavaFileManager fileManager = jc.getStandardFileManager(null, null, null);
-		Iterable<? extends JavaFileObject> units = fileManager.getJavaFileObjectsFromStrings(classes);
+		Iterable<? extends JavaFileObject> units = fileManager.getJavaFileObjectsFromFiles(classes);
 		//set compiler options
 		ArrayList<String> copt = new ArrayList<String>();
 		

--- a/org.coreasm.engine/src/org/coreasm/compiler/classlibrary/AbstractLibraryEntry.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/classlibrary/AbstractLibraryEntry.java
@@ -36,7 +36,7 @@ public abstract class AbstractLibraryEntry implements LibraryEntry {
 	@Override
 	public void writeFile() throws LibraryEntryException {
 		File file = getFile();
-		File directory = new File(file.getParent() + "\\");
+		File directory = file.getParentFile();
 		
 		if(file.exists()){
 			throw new LibraryEntryException(new Exception("file " + file.getPath() + " already exists"));

--- a/org.coreasm.engine/src/org/coreasm/compiler/classlibrary/ClassFile.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/classlibrary/ClassFile.java
@@ -85,12 +85,14 @@ public class ClassFile extends AbstractLibraryEntry{
 
 	@Override
 	protected File getFile() {
-		String pkg = packageName.replace(".", "\\"); //create the path from the packagename
-		if(pkg.equals("")){
-			return new File(CoreASMCompiler.getEngine().getOptions().tempDirectory + "\\" + className + ".java");
+		File tempDirectory = new File(CoreASMCompiler.getEngine().getOptions().tempDirectory);
+
+		if(packageName.equals("")){
+			return new File(tempDirectory, className + ".java");
 		}
 		else{
-			return new File(CoreASMCompiler.getEngine().getOptions().tempDirectory + "\\" + pkg + "\\" + className + ".java");
+			String pkg = packageName.replace(".", File.separator); //create the path from the packagename
+			return new File(tempDirectory, pkg + File.separator + className + ".java");
 		}
 	}
 	

--- a/org.coreasm.engine/src/org/coreasm/compiler/classlibrary/ClassInclude.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/classlibrary/ClassInclude.java
@@ -34,7 +34,7 @@ import org.coreasm.compiler.exception.LibraryEntryException;
  */
 public class ClassInclude implements LibraryEntry{
 	
-	private String jarArchive;
+	private File jarArchive;
 	//private JarFile jarArchive;
 	private String className;
 	private File originalPath;
@@ -47,28 +47,32 @@ public class ClassInclude implements LibraryEntry{
 	/**
 	 * The base path to the plugins. Used to make the merge with the coreasm project easier.
 	 */
-	public final static String PLUGIN_BASE = "src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\";
+	public static final String PLUGIN_BASE = "src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\".replace("\\", File.separator);
 	
 	/**
 	 * Creates a new ClassInclude object referencing a file on the hard disk.
 	 * @param path The path of the source file
 	 * @param packageName The target package name of the include
 	 */
-	public ClassInclude(String path, String packageName){
+	public ClassInclude(File path, String packageName){
+		if (!path.exists()) {
+			CoreASMCompiler.getEngine().addWarning("File " + path.getAbsolutePath() + " does not exist");
+			CoreASMCompiler.getEngine().getLogger().warn(ClassInclude.class, "Error while constructing ClassInclude");
+		}
 		
 		jarArchive = null;
 		
-		originalPath = new File(path);
+		originalPath = path;
 		
 		CompilerOptions options = CoreASMCompiler.getEngine().getOptions();
 		
-		targetDirectory = new File(options.tempDirectory + "\\" + packageName.replace(".", "\\"));
+		targetDirectory = new File(options.tempDirectory + File.separator + packageName.replace(".", File.separator));
 		
-		String tFile = options.tempDirectory + "\\" + packageName.replace(".", "\\") + ((!packageName.equals("")) ? "\\" : "") + originalPath.getName();
+		String tFile = originalPath.getName();
 		if(!tFile.endsWith(".java")){
 			tFile += ".java";
 		}
-		targetFile = new File(tFile);
+		targetFile = new File(targetDirectory, tFile);
 		
 		className = originalPath.getName();
 		
@@ -85,19 +89,19 @@ public class ClassInclude implements LibraryEntry{
 	 * @param packageName The target package name
 	 * @throws IOException If the jar archive could not be accessed
 	 */
-	public ClassInclude(String jarPath, String className, String packageName) throws IOException{
+	public ClassInclude(File jarPath, String className, String packageName) throws IOException{
 		jarArchive = jarPath;
 		//jarArchive = new JarFile(jarPath);
 		this.className = className;
 		originalPath = null;
 		CompilerOptions options = CoreASMCompiler.getEngine().getOptions();
-		targetDirectory = new File(options.tempDirectory + "\\" + packageName.replace(".", "\\"));
+		targetDirectory = new File(options.tempDirectory + File.separator + packageName.replace(".", File.separator));
 		
-		String tFile = options.tempDirectory + "\\" + packageName.replace(".", "\\") + ((!packageName.equals("")) ? "\\" : "") + className.substring(Math.max(0, className.lastIndexOf("/")));
+		String tFile = className.substring(Math.max(0, className.lastIndexOf("/")));
 		if(!tFile.endsWith(".java")){
 			tFile += ".java";
 		}
-		targetFile = new File(tFile);
+		targetFile = new File(targetDirectory, tFile);
 		this.packageName = packageName;
 		importReplacements = new HashMap<String, String>();
 		populatePackageReplacements();

--- a/org.coreasm.engine/src/org/coreasm/compiler/classlibrary/ClassLibrary.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/classlibrary/ClassLibrary.java
@@ -1,5 +1,6 @@
 package org.coreasm.compiler.classlibrary;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -128,7 +129,7 @@ public class ClassLibrary {
 	 * @return A new ClassInclude LibraryEntry for the included class.
 	 * @throws EntryAlreadyExistsException If there already is an entry with the given full name
 	 */
-	public ClassInclude includeClass(String path, CompilerPlugin source) throws EntryAlreadyExistsException{
+	public ClassInclude includeClass(File path, CompilerPlugin source) throws EntryAlreadyExistsException {
 		ClassInclude result = new ClassInclude(path, PLUGINBASEPACKAGE + "." + source.getName());
 		if(this.entries.contains(result)) throw new EntryAlreadyExistsException(result.getFullName());
 		this.entries.add(result);
@@ -144,7 +145,7 @@ public class ClassLibrary {
 	 * @throws IncludeException If there was some problem with the jar archive 
 	 * @throws EntryAlreadyExistsException If an entry with the constructed full name already exists
 	 */
-	public ClassInclude includeClass(String jarPath, String classPath, CompilerPlugin source) throws IncludeException, EntryAlreadyExistsException{
+	public ClassInclude includeClass(File jarPath, String classPath, CompilerPlugin source) throws IncludeException, EntryAlreadyExistsException{
 		try{
 			ClassInclude result = new ClassInclude(jarPath, classPath, PLUGINBASEPACKAGE + "." + source.getName());
 			if(this.entries.contains(result)) throw new EntryAlreadyExistsException(result.getFullName());
@@ -174,13 +175,13 @@ public class ClassLibrary {
 	 * @return A list of generated files with their full paths. This can be used to compile the generated classes
 	 * @throws LibraryEntryException If a LibraryEntry failed to write its contents to the disk
 	 */
-	public ArrayList<String> dumpClasses() throws LibraryEntryException{
+	public ArrayList<File> dumpClasses() throws LibraryEntryException{
 		CoreASMCompiler.getEngine().getLogger().debug(ClassLibrary.class, "starting class dump, library contains the following classes:");
 		//debug output: list all files in the class library
 		for(LibraryEntry e : entries){
 			CoreASMCompiler.getEngine().getLogger().debug(ClassLibrary.class, e.getFullName());
 		}
-		ArrayList<String> result = new ArrayList<String>();
+		ArrayList<File> result = new ArrayList<File>();
 		
 		boolean hadError = false;
 		
@@ -196,20 +197,22 @@ public class ClassLibrary {
 				}
 			}
 			
+			File f = new File(options.tempDirectory + File.separator + e.getFullName().replace(".", File.separator) + ".java");
 			CoreASMCompiler.getEngine().getLogger().debug(ClassLibrary.class, "current entry: " + e.toString());
-			CoreASMCompiler.getEngine().getLogger().debug(ClassLibrary.class, "dumping class " + options.tempDirectory + "\\" + e.getFullName().replace(".", "\\") + ".java");
+			CoreASMCompiler.getEngine().getLogger().debug(ClassLibrary.class, "dumping class " + f);
 			//write the library Entry
 			try{
 				e.writeFile();
 				CoreASMCompiler.getEngine().getLogger().debug(ClassLibrary.class, "success");
 			}
 			catch(LibraryEntryException exc){
-				CoreASMCompiler.getEngine().addError("entry " + options.tempDirectory + "\\" + e.getFullName().replace(".", "\\") + ".java" + " had errors");
+				CoreASMCompiler.getEngine().addError("entry " + f + " had errors");
 				hadError = true;
 			}
 			
 			//add the printed file to the list of generated files
-			result.add(options.tempDirectory + "\\" + e.getFullName().replace(".", "\\") + ".java");
+			// TODO: check if the written file has the expected path?
+			result.add(f); // TODO: String!!
 		}
 		
 		if(hadError) throw new LibraryEntryException("");

--- a/org.coreasm.engine/src/org/coreasm/compiler/classlibrary/ConstantFunctionLibraryEntry.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/classlibrary/ConstantFunctionLibraryEntry.java
@@ -24,7 +24,7 @@ public class ConstantFunctionLibraryEntry extends AbstractLibraryEntry {
 
 	@Override
 	protected File getFile() {
-		return new File(CoreASMCompiler.getEngine().getOptions().tempDirectory + "\\" + pckg.replace(".", "\\") + "\\" + "const_function_" + fname + ".java");
+		return new File(CoreASMCompiler.getEngine().getOptions().tempDirectory + File.separator + pckg.replace(".", File.separator) + File.separator + "const_function_" + fname + ".java");
 	}
 
 	@Override

--- a/org.coreasm.engine/src/org/coreasm/compiler/classlibrary/EnumFile.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/classlibrary/EnumFile.java
@@ -48,9 +48,9 @@ public class EnumFile extends AbstractLibraryEntry{
 	@Override
 	protected File getFile() {
 		if(packageName.equals(""))
-			return new File(CoreASMCompiler.getEngine().getOptions().tempDirectory + "\\" + enumName + ".java");
+			return new File(CoreASMCompiler.getEngine().getOptions().tempDirectory + File.separator + enumName + ".java");
 		else
-			return new File(CoreASMCompiler.getEngine().getOptions().tempDirectory + "\\" + packageName.replace(".", "\\") + "\\" + enumName + ".java");
+			return new File(CoreASMCompiler.getEngine().getOptions().tempDirectory + File.separator + packageName.replace(".", File.separator) + File.separator + enumName + ".java");
 	}
 
 	@Override

--- a/org.coreasm.engine/src/org/coreasm/compiler/classlibrary/RuleClassFile.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/classlibrary/RuleClassFile.java
@@ -85,7 +85,7 @@ public class RuleClassFile extends AbstractLibraryEntry {
 	
 	@Override
 	protected File getFile() {
-		return new File(CoreASMCompiler.getEngine().getOptions().tempDirectory + "\\Rules\\" + ruleName + ".java");
+		return new File(CoreASMCompiler.getEngine().getOptions().tempDirectory + File.separator + "Rules" + File.separator + ruleName + ".java");
 	}
 
 	@Override

--- a/org.coreasm.engine/src/org/coreasm/compiler/mainprogram/MainFile.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/mainprogram/MainFile.java
@@ -308,8 +308,8 @@ public class MainFile implements LibraryEntry{
 		finalContent.appendLine("}");
 		
 		
-		File file = new File(CoreASMCompiler.getEngine().getOptions().tempDirectory + "\\Main.java");
-		File directory = new File(CoreASMCompiler.getEngine().getOptions().tempDirectory + "\\");
+		File directory = new File(CoreASMCompiler.getEngine().getOptions().tempDirectory);
+		File file = new File(directory, "Main.java");
 		if(file.exists()) throw new LibraryEntryException(new Exception("file already exists"));
 		
 		BufferedWriter bw = null;

--- a/org.coreasm.engine/src/org/coreasm/compiler/plugins/collection/CompilerCollectionPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/plugins/collection/CompilerCollectionPlugin.java
@@ -1,5 +1,6 @@
 package org.coreasm.compiler.plugins.collection;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,13 +56,15 @@ public class CompilerCollectionPlugin extends CompilerCodePlugin implements Comp
 		ClassLibrary library = CoreASMCompiler.getEngine().getClassLibrary();
 		
 		
-		String enginePath = CoreASMCompiler.getEngine().getOptions().enginePath;
-		if(enginePath == null){
+		String enginePathStr = CoreASMCompiler.getEngine().getOptions().enginePath;
+		if(enginePathStr == null){
 			try {
+				File collectionFolder = new File("src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\collection\\include".replace("\\", File.separator));
+
 				// these classes need a replacement import
 				ClassInclude include = library
 						.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\collection\\include\\AbstractBagElement.java",
+								new File(collectionFolder, "AbstractBagElement.java"),
 								this);
 				include.addImportReplacement(
 						"org.coreasm.compiler.dummy.numberplugin.include.NumberElement",
@@ -70,7 +73,7 @@ public class CompilerCollectionPlugin extends CompilerCodePlugin implements Comp
 	
 				include = library
 						.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\collection\\include\\AbstractListElement.java",
+								new File(collectionFolder, "AbstractListElement.java"),
 								this);
 				include.addImportReplacement(
 						"org.coreasm.compiler.dummy.numberplugin.include.NumberElement",
@@ -79,7 +82,7 @@ public class CompilerCollectionPlugin extends CompilerCodePlugin implements Comp
 	
 				include = library
 						.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\collection\\include\\ModifiableIndexedCollection.java",
+								new File(collectionFolder, "ModifiableIndexedCollection.java"),
 								this);
 				include.addImportReplacement(
 						"org.coreasm.compiler.dummy.numberplugin.include.NumberElement",
@@ -88,46 +91,47 @@ public class CompilerCollectionPlugin extends CompilerCodePlugin implements Comp
 				// add the other classes
 				result.add(new MainFileEntry(
 						library.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\collection\\include\\AbstractMapElement.java",
+								new File(collectionFolder, "AbstractMapElement.java"),
 								this), EntryType.INCLUDEONLY, ""));
 				result.add(new MainFileEntry(
 						library.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\collection\\include\\AbstractSetElement.java",
+								new File(collectionFolder, "AbstractSetElement.java"),
 								this), EntryType.INCLUDEONLY, ""));
 				result.add(new MainFileEntry(
 						library.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\collection\\include\\ModifiableCollection.java",
+								new File(collectionFolder, "ModifiableCollection.java"),
 								this), EntryType.INCLUDEONLY, ""));
 	
 				result.add(new MainFileEntry(
 						library.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\collection\\include\\CollectionFunctionElement.java",
+								new File(collectionFolder, "CollectionFunctionElement.java"),
 								this), EntryType.INCLUDEONLY, ""));
 				result.add(new MainFileEntry(
 						library.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\collection\\include\\FilterFunctionElement.java",
+								new File(collectionFolder, "FilterFunctionElement.java"),
 								this), EntryType.FUNCTION, FilterName));
 				result.add(new MainFileEntry(
 						library.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\collection\\include\\FoldFunctionElement.java",
+								new File(collectionFolder, "FoldFunctionElement.java"),
 								this), EntryType.FUNCTION, FoldName));
 				result.add(new MainFileEntry(
 						library.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\collection\\include\\FoldFunctionElement.java",
+								new File(collectionFolder, "FoldFunctionElement.java"),
 								this), EntryType.FUNCTION, FoldLName));
 				result.add(new MainFileEntry(
 						library.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\collection\\include\\FoldrFunctionElement.java",
+								new File(collectionFolder, "FoldrFunctionElement.java"),
 								this), EntryType.FUNCTION, FoldRName));
 				result.add(new MainFileEntry(
 						library.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\collection\\include\\MapFunctionElement.java",
+								new File(collectionFolder, "MapFunctionElement.java"),
 								this), EntryType.FUNCTION, MapName));
 			} catch (EntryAlreadyExistsException e) {
 				throw new CompilerException(e);
 			}
 		}
 		else{
+			File enginePath = new File(enginePathStr);
 			
 			try {
 				//add package replacements for imported classes which can be used by other plugins

--- a/org.coreasm.engine/src/org/coreasm/compiler/plugins/io/CompilerIOPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/plugins/io/CompilerIOPlugin.java
@@ -1,5 +1,6 @@
 package org.coreasm.compiler.plugins.io;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,32 +42,34 @@ public class CompilerIOPlugin extends CompilerCodePlugin implements CompilerPlug
 
 	@Override
 	public List<MainFileEntry> loadClasses(ClassLibrary classLibrary) throws CompilerException {
-		String enginePath = CoreASMCompiler.getEngine().getOptions().enginePath;
+		String enginePathStr = CoreASMCompiler.getEngine().getOptions().enginePath;
 		List<MainFileEntry> result = new ArrayList<MainFileEntry>();
 		
-		if(enginePath == null){
+		if(enginePathStr == null){
 			classLibrary.addPackageReplacement("org.coreasm.compiler.dummy.stringplugin.include.StringElement", 
 					"plugins.StringPlugin.StringElement");
 			
 			try{
+				File iopluginFolder = new File("src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\ioplugin\\include".replace("\\", File.separator));
+
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\ioplugin\\include\\OutputFunctionElement.java", 
+						new File(iopluginFolder, "OutputFunctionElement.java"),
 						this), EntryType.FUNCTION, "output"));
 		
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\ioplugin\\include\\InputFunctionElement.java", 
+						new File(iopluginFolder, "InputFunctionElement.java"),
 						this), EntryType.FUNCTION, "input"));
 		
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\ioplugin\\include\\InputProvider.java", 
+						new File(iopluginFolder, "InputProvider.java"),
 						this), EntryType.INCLUDEONLY, ""));
 		
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\ioplugin\\include\\IOHelper.java", 
+						new File(iopluginFolder, "IOHelper.java"),
 						this), EntryType.INCLUDEONLY, ""));
 		
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\ioplugin\\include\\IOAggregator.java", 
+						new File(iopluginFolder, "IOAggregator.java"),
 						this), EntryType.AGGREGATOR, ""));
 			}
 			catch(EntryAlreadyExistsException e){
@@ -75,6 +78,8 @@ public class CompilerIOPlugin extends CompilerCodePlugin implements CompilerPlug
 		}
 		else{			
 			try {
+				File enginePath = new File(enginePathStr);
+
 				//classLibrary.addPackageReplacement("org.coreasm.engine.plugins.string.StringElement", "plugins.StringPlugin.StringElement");
 				
 				//add package replacements for classes accessible for other plugins

--- a/org.coreasm.engine/src/org/coreasm/compiler/plugins/list/CompilerListPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/plugins/list/CompilerListPlugin.java
@@ -1,5 +1,6 @@
 package org.coreasm.compiler.plugins.list;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -100,71 +101,71 @@ public class CompilerListPlugin extends CompilerCodePlugin implements CompilerPl
 	@Override
 	public List<MainFileEntry> loadClasses(ClassLibrary classLibrary) throws CompilerException {
 		
-		String enginePath = CoreASMCompiler.getEngine().getOptions().enginePath;
+		String enginePathStr = CoreASMCompiler.getEngine().getOptions().enginePath;
 		List<MainFileEntry> result = new ArrayList<MainFileEntry>();
 		
-		if(enginePath==null){
+		if(enginePathStr == null){
 			classLibrary.addPackageReplacement("org.coreasm.compiler.dummy.collection.include.AbstractListElement", "plugins.CollectionPlugin.AbstractListElement");
 			classLibrary.addPackageReplacement("org.coreasm.compiler.dummy.collection.include.ModifiableIndexedCollection", "plugins.CollectionPlugin.ModifiableIndexedCollection");
 			classLibrary.addPackageReplacement("org.coreasm.compiler.dummy.numberplugin.include.NumberElement", "plugins.NumberPlugin.NumberElement");
 			classLibrary.addPackageReplacement("org.coreasm.compiler.dummy.numberplugin.include.NumberBackgroundElement", "plugins.NumberPlugin.NumberBackgroundElement");
 			
 			try{
-				
-				
+				File listpluginFolder = new File("src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include".replace("\\", File.separator));
+
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\ConsFunctionElement.java", 
+						new File(listpluginFolder, "ConsFunctionElement.java"),
 						this), EntryType.FUNCTION, "cons"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\DropFunctionElement.java", 
+						new File(listpluginFolder, "DropFunctionElement.java"),
 						this), EntryType.FUNCTION, "drop"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\FlattenListFunctionElement.java", 
+						new File(listpluginFolder, "FlattenListFunctionElement.java"),
 						this), EntryType.FUNCTION, "flattenList"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\HeadFunctionElement.java", 
+						new File(listpluginFolder, "HeadFunctionElement.java"),
 						this), EntryType.FUNCTION, "head"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\IndexesFunctionElement.java", 
+						new File(listpluginFolder, "IndexesFunctionElement.java"),
 						this), EntryType.FUNCTION, "indices"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\LastFunctionElement.java", 
+						new File(listpluginFolder, "LastFunctionElement.java"),
 						this), EntryType.FUNCTION, "last"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\ListBackgroundElement.java", 
+						new File(listpluginFolder, "ListBackgroundElement.java"),
 						this), EntryType.BACKGROUND, "LIST"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\ListElement.java", 
+						new File(listpluginFolder, "ListElement.java"),
 						this), EntryType.INCLUDEONLY, ""));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\ListFunctionElement.java", 
+						new File(listpluginFolder, "ListFunctionElement.java"),
 						this), EntryType.INCLUDEONLY, ""));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\NthFunctionElement.java", 
+						new File(listpluginFolder, "NthFunctionElement.java"),
 						this), EntryType.FUNCTION, "nth"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\ReplicateFunctionElement.java", 
+						new File(listpluginFolder, "ReplicateFunctionElement.java"),
 						this), EntryType.FUNCTION, "replicate"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\ReverseFunctionElement.java", 
+						new File(listpluginFolder, "ReverseFunctionElement.java"),
 						this), EntryType.FUNCTION, "reverse"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\SetNthFunctionElement.java", 
+						new File(listpluginFolder, "SetNthFunctionElement.java"),
 						this), EntryType.FUNCTION, "setnth"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\TailFunctionElement.java", 
+						new File(listpluginFolder, "TailFunctionElement.java"),
 						this), EntryType.FUNCTION, "tail"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\TakeFunctionElement.java", 
+						new File(listpluginFolder, "TakeFunctionElement.java"),
 						this), EntryType.FUNCTION, "take"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\ToListFunctionElement.java", 
+						new File(listpluginFolder, "ToListFunctionElement.java"),
 						this), EntryType.FUNCTION, "toList"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\ZipFunctionElement.java", 
+						new File(listpluginFolder, "ZipFunctionElement.java"),
 						this), EntryType.FUNCTION, "zip"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\listplugin\\include\\ZipWithFunctionElement.java", 
+						new File(listpluginFolder, "ZipWithFunctionElement.java"),
 						this), EntryType.FUNCTION, "zipwith"));
 			}
 			catch(EntryAlreadyExistsException e){
@@ -173,6 +174,8 @@ public class CompilerListPlugin extends CompilerCodePlugin implements CompilerPl
 		}
 		else{
 			try {
+				File enginePath = new File(enginePathStr);
+
 				//replacements for packages
 				/*classLibrary.addPackageReplacement("org.coreasm.engine.plugins.collection.AbstractListElement", "plugins.CollectionPlugin.AbstractListElement");
 				classLibrary.addPackageReplacement("org.coreasm.engine.plugins.number.include.NumberElement", "plugins.NumberPlugin.NumberElement");

--- a/org.coreasm.engine/src/org/coreasm/compiler/plugins/map/CompilerMapPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/plugins/map/CompilerMapPlugin.java
@@ -1,5 +1,6 @@
 package org.coreasm.compiler.plugins.map;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,10 +38,10 @@ public class CompilerMapPlugin extends CompilerCodePlugin implements CompilerPlu
 	@Override
 	public List<MainFileEntry> loadClasses(ClassLibrary classLibrary)
 			throws CompilerException {
-		String enginePath = CoreASMCompiler.getEngine().getOptions().enginePath;
+		String enginePathStr = CoreASMCompiler.getEngine().getOptions().enginePath;
 		List<MainFileEntry> result = new ArrayList<MainFileEntry>();
 		
-		if(enginePath == null){
+		if(enginePathStr == null){
 			classLibrary
 					.addPackageReplacement(
 							"org.coreasm.compiler.dummy.collection.include.AbstractListElement",
@@ -67,25 +68,27 @@ public class CompilerMapPlugin extends CompilerCodePlugin implements CompilerPlu
 							"plugins.SetPlugin.SetElement");
 	
 			try {
+				File mappluginFolder = new File("src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\mapplugin\\include".replace("\\", File.separator));
+
 				result.add(new MainFileEntry(
 						classLibrary
 								.includeClass(
-										"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\mapplugin\\include\\MapToPairsFunctionElement.java",
+										new File(mappluginFolder, "MapToPairsFunctionElement.java"),
 										this), EntryType.FUNCTION, "mapToPairs"));
 				result.add(new MainFileEntry(
 						classLibrary
 								.includeClass(
-										"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\mapplugin\\include\\ToMapFunctionElement.java",
+										new File(mappluginFolder, "ToMapFunctionElement.java"),
 										this), EntryType.FUNCTION, "toMap"));
 				result.add(new MainFileEntry(
 						classLibrary
 								.includeClass(
-										"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\mapplugin\\include\\MapBackgroundElement.java",
+										new File(mappluginFolder, "MapBackgroundElement.java"),
 										this), EntryType.BACKGROUND, "MAP"));
 				result.add(new MainFileEntry(
 						classLibrary
 								.includeClass(
-										"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\mapplugin\\include\\MapElement.java",
+										new File(mappluginFolder, "MapElement.java"),
 										this), EntryType.INCLUDEONLY, ""));
 			} catch (EntryAlreadyExistsException e) {
 				throw new CompilerException(e);
@@ -94,6 +97,8 @@ public class CompilerMapPlugin extends CompilerCodePlugin implements CompilerPlu
 		}
 		else{
 			try {
+				File enginePath = new File(enginePathStr);
+
 				//classLibrary.addPackageReplacement("org.coreasm.engine.plugins.collection.AbstractMapElement", "plugins.CollectionPlugin.AbstractMapElement");
 				//classLibrary.addPackageReplacement("org.coreasm.compiler.plugins.collection.include.ModifiableCollection", "plugins.CollectionPlugin.ModifiableCollection");
 				//classLibrary.addPackageReplacement("org.coreasm.engine.plugins.list.ListElement", "plugins.ListPlugin.ListElement");

--- a/org.coreasm.engine/src/org/coreasm/compiler/plugins/math/CompilerMathPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/plugins/math/CompilerMathPlugin.java
@@ -1,5 +1,6 @@
 package org.coreasm.compiler.plugins.math;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -43,10 +44,12 @@ public class CompilerMathPlugin extends CompilerCodePlugin implements CompilerPl
 
 		List<MainFileEntry> result = new ArrayList<MainFileEntry>();
 		
-		String enginePath = CoreASMCompiler.getEngine().getOptions().enginePath;
+		String enginePathStr = CoreASMCompiler.getEngine().getOptions().enginePath;
 		
-		if(enginePath == null){
+		if(enginePathStr == null){
 			try {
+				File mathpluginFolder = new File("src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\mathplugin\\include".replace("\\", File.separator));
+
 				classLibrary
 						.addPackageReplacement(
 								"org.coreasm.compiler.dummy.setplugin.include.SetElement",
@@ -58,12 +61,12 @@ public class CompilerMathPlugin extends CompilerCodePlugin implements CompilerPl
 				result.add(new MainFileEntry(
 						classLibrary
 								.includeClass(
-										"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\mathplugin\\include\\MathFunction.java",
+										new File(mathpluginFolder, "MathFunction.java"),
 										this), EntryType.INCLUDEONLY, ""));
 				result.add(new MainFileEntry(
 						classLibrary
 								.includeClass(
-										"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\mathplugin\\include\\PowerSetElement.java",
+										new File(mathpluginFolder, "PowerSetElement.java"),
 										this), EntryType.INCLUDEONLY, ""));
 	
 				for (Entry<String, MathFunctionEntry> e : functions.entrySet()) {
@@ -77,6 +80,8 @@ public class CompilerMathPlugin extends CompilerCodePlugin implements CompilerPl
 		}
 		else{
 			try {
+				File enginePath = new File(enginePathStr);
+
 				//classLibrary.addPackageReplacement("org.coreasm.engine.plugins.set.SetElement", "plugins.SetPlugin.SetElement");
 				classLibrary.addPackageReplacement("org.coreasm.engine.plugins.math.MathFunction", "plugins.MathPlugin.MathFunction");
 				classLibrary.addPackageReplacement("org.coreasm.compiler.plugins.math.include.PowerSetElement", "plugins.MathPlugin.PowerSetElement");

--- a/org.coreasm.engine/src/org/coreasm/compiler/plugins/math/MathFunctionEntry.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/plugins/math/MathFunctionEntry.java
@@ -34,8 +34,8 @@ public class MathFunctionEntry implements LibraryEntry {
 	@Override
 	public void writeFile() throws LibraryEntryException {
 		CompilerOptions options = CoreASMCompiler.getEngine().getOptions();
-		File file = new File(options.tempDirectory + "\\plugins\\MathPlugin\\" + name + ".java");
-		File directory = new File(options.tempDirectory + "\\plugins\\MathPlugin\\");
+		File directory = new File(options.tempDirectory + File.separator + "plugins" + File.separator + "MathPlugin");
+		File file = new File(directory, name + ".java");
 		
 		if(file.exists()) throw new LibraryEntryException(new Exception("file already exists"));
 		

--- a/org.coreasm.engine/src/org/coreasm/compiler/plugins/number/CompilerNumberPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/plugins/number/CompilerNumberPlugin.java
@@ -1,5 +1,6 @@
 package org.coreasm.compiler.plugins.number;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +51,7 @@ public class CompilerNumberPlugin extends CompilerCodePlugin implements
 			List<MainFileEntry> result = new ArrayList<MainFileEntry>();
 			ClassLibrary library = CoreASMCompiler.getEngine().getClassLibrary();
 
-			String jarpath = CoreASMCompiler.getEngine().getOptions().enginePath;
+			File jarpath = new File(CoreASMCompiler.getEngine().getOptions().enginePath);
 			
 			try{
 				library.addPackageReplacement("org.coreasm.engine.plugins.number.NumberElement", "plugins.NumberPlugin.NumberElement");

--- a/org.coreasm.engine/src/org/coreasm/compiler/plugins/set/CompilerSetPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/plugins/set/CompilerSetPlugin.java
@@ -1,7 +1,9 @@
 package org.coreasm.compiler.plugins.set;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.coreasm.compiler.classlibrary.ClassLibrary;
 import org.coreasm.compiler.exception.CompilerException;
 import org.coreasm.compiler.exception.EntryAlreadyExistsException;
@@ -126,29 +128,31 @@ public class CompilerSetPlugin extends CompilerCodePlugin implements CompilerPlu
 	
 	@Override
 	public List<MainFileEntry> loadClasses(ClassLibrary classLibrary) throws CompilerException {
-		String enginePath = CoreASMCompiler.getEngine().getOptions().enginePath;
+		String enginePathStr = CoreASMCompiler.getEngine().getOptions().enginePath;
 		List<MainFileEntry> result = new ArrayList<MainFileEntry>();
 		
-		if(enginePath == null){
+		if(enginePathStr == null){
 			classLibrary.addPackageReplacement("org.coreasm.compiler.dummy.numberplugin.include.NumberElement", "plugins.NumberPlugin.NumberElement");
 			classLibrary.addPackageReplacement("org.coreasm.compiler.dummy.collection.include.AbstractSetElement", "plugins.CollectionPlugin.AbstractSetElement");
 			classLibrary.addPackageReplacement("org.coreasm.compiler.dummy.collection.include.ModifiableCollection", "plugins.CollectionPlugin.ModifiableCollection");
 			
 			try{
+				File setpluginFolder = new File("src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\setplugin\\include".replace("\\", File.separator));
+
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\setplugin\\include\\SetBackgroundElement.java", 
+						new File(setpluginFolder, "SetBackgroundElement.java"),
 						this), EntryType.BACKGROUND, "SET"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\setplugin\\include\\SetCardinalityFunctionElement.java", 
+						new File(setpluginFolder, "SetCardinalityFunctionElement.java"),
 						this), EntryType.FUNCTION, "setCardinality"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\setplugin\\include\\SetElement.java", 
+						new File(setpluginFolder, "SetElement.java"),
 						this), EntryType.INCLUDEONLY, ""));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\setplugin\\include\\ToSetFunctionElement.java", 
+						new File(setpluginFolder, "ToSetFunctionElement.java"),
 						this), EntryType.FUNCTION, "toSet"));
 				result.add(new MainFileEntry(classLibrary.includeClass(
-						"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\setplugin\\include\\SetAggregator.java", 
+						new File(setpluginFolder, "SetAggregator.java"),
 						this), EntryType.AGGREGATOR, ""));
 			}
 			catch(EntryAlreadyExistsException e){
@@ -157,6 +161,8 @@ public class CompilerSetPlugin extends CompilerCodePlugin implements CompilerPlu
 		}
 		else{
 			try {
+				File enginePath = new File(enginePathStr);
+
 				//classLibrary.addPackageReplacement("org.coreasm.engine.plugins.collection.AbstractSetElement", "plugins.CollectionPlugin.AbstractSetElement");
 				//classLibrary.addPackageReplacement("org.coreasm.compiler.plugins.collection.include.ModifiableCollection", "plugins.CollectionPlugin.ModifiableCollection");
 				

--- a/org.coreasm.engine/src/org/coreasm/compiler/plugins/signature/CompilerSignaturePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/plugins/signature/CompilerSignaturePlugin.java
@@ -1,5 +1,6 @@
 package org.coreasm.compiler.plugins.signature;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -68,27 +69,29 @@ public class CompilerSignaturePlugin extends CompilerCodePlugin implements Compi
 	@Override
 	public List<MainFileEntry> loadClasses(ClassLibrary classLibrary) throws CompilerException{
 		
-		String enginePath = CoreASMCompiler.getEngine().getOptions().enginePath;
+		String enginePathStr = CoreASMCompiler.getEngine().getOptions().enginePath;
 		List<MainFileEntry> result = new ArrayList<MainFileEntry>();
 		
-		if(enginePath == null){
+		if(enginePathStr == null){
 		
 			classLibrary.addPackageReplacement("org.coreasm.compiler.dummy.listplugin.include.ListElement", "plugins.ListPlugin.ListElement");
 			classLibrary.addPackageReplacement("org.coreasm.compiler.dummy.setplugin.include.SetElement", "plugins.SetPlugin.SetElement");
 			
 			
 			try{
+				File signaturepluginFolder = new File(ClassInclude.PLUGIN_BASE + "signatureplugin\\include".replace("\\", File.separator));
+
 				result.add(new MainFileEntry(
-						classLibrary.includeClass(ClassInclude.PLUGIN_BASE + "signatureplugin\\include\\EnumerationBackgroundElement.java",
+						classLibrary.includeClass(new File(signaturepluginFolder, "EnumerationBackgroundElement.java"),
 								this), EntryType.INCLUDEONLY,""));
 				result.add(new MainFileEntry(
-						classLibrary.includeClass(ClassInclude.PLUGIN_BASE + "signatureplugin\\include\\EnumerationElement.java",
+						classLibrary.includeClass(new File(signaturepluginFolder, "EnumerationElement.java"),
 								this), EntryType.INCLUDEONLY,""));
 				result.add(new MainFileEntry(
-						classLibrary.includeClass(ClassInclude.PLUGIN_BASE + "signatureplugin\\include\\FunctionDomainFunctionElement.java",
+						classLibrary.includeClass(new File(signaturepluginFolder, "FunctionDomainFunctionElement.java"),
 								this), EntryType.FUNCTION,"domain"));
 				result.add(new MainFileEntry(
-						classLibrary.includeClass(ClassInclude.PLUGIN_BASE + "signatureplugin\\include\\FunctionRangeFunctionElement.java",
+						classLibrary.includeClass(new File(signaturepluginFolder, "FunctionRangeFunctionElement.java"),
 								this), EntryType.FUNCTION,"range"));
 				
 				
@@ -99,6 +102,8 @@ public class CompilerSignaturePlugin extends CompilerCodePlugin implements Compi
 		}
 		else{
 			try {
+				File enginePath = new File(enginePathStr);
+
 				classLibrary.addPackageReplacement("org.coreasm.engine.plugins.signature.EnumerationBackgroundElement", "plugins.SignaturePlugin.EnumerationBackgroundElement");
 				classLibrary.addPackageReplacement("org.coreasm.engine.plugins.signature.EnumerationElement", "plugins.SignaturePlugin.EnumerationElement");
 				

--- a/org.coreasm.engine/src/org/coreasm/compiler/plugins/signature/EnumBackgroundEntry.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/plugins/signature/EnumBackgroundEntry.java
@@ -32,8 +32,8 @@ public class EnumBackgroundEntry implements LibraryEntry {
 	@Override
 	public void writeFile() throws LibraryEntryException {
 		CompilerOptions options = CoreASMCompiler.getEngine().getOptions();
-		File file = new File(options.tempDirectory + "\\plugins\\SignaturePlugin\\EnumBackground_" + name + ".java");
-		File directory = new File(options.tempDirectory + "\\plugins\\SignaturePlugin\\");
+		File directory = new File(options.tempDirectory + File.separator + "plugins" + File.separator + "SignaturePlugin");
+		File file = new File(directory, "EnumBackground_" + name + ".java");
 		
 		if(file.exists()) throw new LibraryEntryException(new Exception("file already exists"));
 		

--- a/org.coreasm.engine/src/org/coreasm/compiler/plugins/signature/FunctionEntry.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/plugins/signature/FunctionEntry.java
@@ -44,8 +44,8 @@ public class FunctionEntry implements LibraryEntry {
 	@Override
 	public void writeFile() throws LibraryEntryException {
 		CompilerOptions options = CoreASMCompiler.getEngine().getOptions();
-		File file = new File(options.tempDirectory + "\\plugins\\SignaturePlugin\\Func_" + name + ".java");
-		File directory = new File(options.tempDirectory + "\\plugins\\SignaturePlugin\\");
+		File directory = new File(options.tempDirectory + File.separator + "plugins" + File.separator + "SignaturePlugin");
+		File file = new File(directory, "Func_" + name + ".java");
 		
 		if(file.exists()) throw new LibraryEntryException(new Exception("file already exists"));
 		

--- a/org.coreasm.engine/src/org/coreasm/compiler/plugins/signature/UniverseEntry.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/plugins/signature/UniverseEntry.java
@@ -32,8 +32,8 @@ public class UniverseEntry implements LibraryEntry {
 	@Override
 	public void writeFile() throws LibraryEntryException {
 		CompilerOptions options = CoreASMCompiler.getEngine().getOptions();
-		File file = new File(options.tempDirectory + "\\plugins\\SignaturePlugin\\Universe_" + name + ".java");
-		File directory = new File(options.tempDirectory + "\\plugins\\SignaturePlugin\\");
+		File directory = new File(options.tempDirectory + File.separator + "plugins" + File.separator + "SignaturePlugin");
+		File file = new File(directory, "Universe_" + name + ".java");
 		
 		if(file.exists()) throw new LibraryEntryException(new Exception("file already exists"));
 		

--- a/org.coreasm.engine/src/org/coreasm/compiler/plugins/string/CompilerStringPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/plugins/string/CompilerStringPlugin.java
@@ -1,5 +1,6 @@
 package org.coreasm.compiler.plugins.string;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -53,26 +54,28 @@ public class CompilerStringPlugin extends CompilerCodePlugin implements Compiler
 	
 		try {
 			
-			String enginePath = CoreASMCompiler.getEngine().getOptions().enginePath;
-			if(enginePath == null){
+			String enginePathStr = CoreASMCompiler.getEngine().getOptions().enginePath;
+			if(enginePathStr == null){
+				File stringpluginFolder = new File("src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\stringplugin\\include".replace("\\", File.separator));
+
 				result.add(new MainFileEntry(
 						library.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\stringplugin\\include\\StringBackgroundElement.java",
+								new File(stringpluginFolder, "StringBackgroundElement.java"),
 								this), EntryType.BACKGROUND, "STRING"));
 	
 				result.add(new MainFileEntry(
 						library.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\stringplugin\\include\\StringElement.java",
+								new File(stringpluginFolder, "StringElement.java"),
 								this), EntryType.INCLUDEONLY, ""));
 	
 				result.add(new MainFileEntry(
 						library.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\stringplugin\\include\\ToStringFunctionElement.java",
+								new File(stringpluginFolder, "ToStringFunctionElement.java"),
 								this), EntryType.FUNCTION, "toString"));
 	
 				ClassInclude tmp = library
 						.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\stringplugin\\include\\StringLengthFunctionElement.java",
+								new File(stringpluginFolder, "StringLengthFunctionElement.java"),
 								this);
 				tmp.addImportReplacement(
 						"org.coreasm.compiler.dummy.numberplugin.include.NumberElement",
@@ -81,7 +84,7 @@ public class CompilerStringPlugin extends CompilerCodePlugin implements Compiler
 	
 				tmp = library
 						.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\stringplugin\\include\\StringSubstringFunction.java",
+								new File(stringpluginFolder, "StringSubstringFunction.java"),
 								this);
 				tmp.addImportReplacement(
 						"org.coreasm.compiler.dummy.numberplugin.include.NumberElement",
@@ -91,10 +94,12 @@ public class CompilerStringPlugin extends CompilerCodePlugin implements Compiler
 	
 				result.add(new MainFileEntry(
 						library.includeClass(
-								"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\stringplugin\\include\\StringMatchingFunction.java",
+								new File(stringpluginFolder, "StringMatchingFunction.java"),
 								this), EntryType.FUNCTION, "matches"));
 			}
 			else{
+				File enginePath = new File(enginePathStr);
+
 				//load classes from jar archive
 				//classLibrary.addPackageReplacement("org.coreasm.engine.plugins.number.NumberElement", "plugins.NumberPlugin.NumberElement");
 				classLibrary.addPackageReplacement("org.coreasm.engine.plugins.string.StringBackgroundElement", "plugins.StringPlugin.StringBackgroundElement");

--- a/org.coreasm.engine/src/org/coreasm/compiler/plugins/time/CompilerTimePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/compiler/plugins/time/CompilerTimePlugin.java
@@ -1,5 +1,6 @@
 package org.coreasm.compiler.plugins.time;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,10 +35,12 @@ public class CompilerTimePlugin implements CompilerPlugin, CompilerVocabularyExt
 			throws CompilerException {
 		List<MainFileEntry> result = new ArrayList<MainFileEntry>();
 		
-		String enginePath = CoreASMCompiler.getEngine().getOptions().enginePath;
+		String enginePathStr = CoreASMCompiler.getEngine().getOptions().enginePath;
 		
-		if(enginePath == null){
+		if(enginePathStr == null){
 			try {
+				File timepluginFolder = new File("src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\timeplugin\\include".replace("\\", File.separator));
+
 				classLibrary
 						.addPackageReplacement(
 								"de.spellmaker.coreasmc.plugins.dummy.numberplugin.include.NumberElement",
@@ -45,12 +48,12 @@ public class CompilerTimePlugin implements CompilerPlugin, CompilerVocabularyExt
 				result.add(new MainFileEntry(
 						classLibrary
 								.includeClass(
-										"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\timeplugin\\include\\NowFunctionElement.java",
+										new File(timepluginFolder, "NowFunctionElement.java"),
 										this), EntryType.FUNCTION, "now"));
 				result.add(new MainFileEntry(
 						classLibrary
 								.includeClass(
-										"src\\de\\spellmaker\\coreasmc\\plugins\\dummy\\timeplugin\\include\\StepCountFunctionElement.java",
+										new File(timepluginFolder, "StepCountFunctionElement.java"),
 										this), EntryType.FUNCTION_CAPI, "stepcount"));
 			}
 			catch(Exception e){
@@ -59,6 +62,8 @@ public class CompilerTimePlugin implements CompilerPlugin, CompilerVocabularyExt
 		}
 		else{
 			try {
+				File enginePath = new File(enginePathStr);
+
 				//classLibrary.addPackageReplacement("org.coreasm.engine.plugins.number.NumberElement", "plugins.NumberPlugin.NumberElement");
 				
 				result.add(new MainFileEntry(classLibrary.includeClass(enginePath, "org/coreasm/engine/plugins/time/NowFunctionElement.java", this), EntryType.FUNCTION, NowFunctionElement.NOW_FUNC_NAME));


### PR DESCRIPTION
I know that the compiler is still in development; however I tried to run the compiler in my Ubuntu development machine and it failed because all paths are Windows specific. 

I replaced `"\\"` with `File.separator` and tried to use the `new File(File parent, String child)` constructor if the parent folder is already present or used multiple times. On longer paths I used `String.replace` to maintain readability.

I replaced `for(String x : f.list())` with `for(File x : f.listFiles())` for consistency, however the previous solution with Strings was not causing any trouble.

There are a lot of `File` constructions from paths provided in the options, I think it would be better to use `File` instead of `String` already there but I didn't want to change too much.
