### PR TITLE
include Location in error message of failed update

### DIFF
--- a/org.coreasm.engine/src/org/coreasm/engine/parser/ParserTools.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/parser/ParserTools.java
@@ -98,9 +98,7 @@ public class ParserTools
 			Parser<Node> parser = terminals_keyw.token(keyword).map(new Map<Token, Node>() {
 				@Override
 				public Node map(Token from) {
-					int index = -1;
-					if (from instanceof Token)
-						index = ((Token)from).index();
+					int index = from.index();
 					return new Node(
 						pluginName,
 						from.toString(),
@@ -119,9 +117,7 @@ public class ParserTools
 			Parser<Node> parser = terminals_keyw.token(operator).map(new Map<Token, Node>() {
 				@Override
 				public Node map(Token from) {
-					int index = -1;
-					if (from instanceof Token)
-						index = ((Token)from).index();
+					int index = from.index();
 					return new Node(
 							"Kernel",
 							from.toString(),

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/bag/BagElement.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/bag/BagElement.java
@@ -44,7 +44,7 @@ public class BagElement extends AbstractBagElement implements ModifiableCollecti
 	protected final Map<Element,Integer> members;
 	
 	// It is a list to improve performance
-	protected List<Element> enumerationCachse = null;
+	protected List<Element> enumerationCache = null;
 	
 	public BagElement() {
 		members = new HashMap<Element,Integer>();
@@ -303,16 +303,16 @@ public class BagElement extends AbstractBagElement implements ModifiableCollecti
 
 	public List<Element> getIndexedView()
 			throws UnsupportedOperationException {
-		if (enumerationCachse == null) {
+		if (enumerationCache == null) {
 			List<Element> result = new ArrayList<Element>();
 			for (Entry<? extends Element, Integer> e: members.entrySet())
 				if (e.getValue() != null && e.getValue() > 0) {
 					for (int i=0; i < e.getValue(); i++)
 						result.add(e.getKey());
 				}
-			enumerationCachse = Collections.unmodifiableList(result);
+			enumerationCache = Collections.unmodifiableList(result);
 		}
-		return enumerationCachse;
+		return enumerationCache;
 	}
 
 	public boolean supportsIndexedView() {

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/collection/CollectionPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/collection/CollectionPlugin.java
@@ -218,7 +218,7 @@ public class CollectionPlugin extends Plugin
 
 						} else
 							capi.error("Incremental add update only applies to modifiable enumerables." + Tools.getEOL() 
-									+ "Failed adding " + atNode.getAddElement() + " to " + collectionNode.getValue() + ".", 
+									+ "Failed adding " + atNode.getAddElement() + " to " + collectionNode.getValue() + " at " + collectionNode.getLocation() + ".",
 									atNode, interpreter);
 					} else
 						capi.error("Cannot perform incremental add update on a non-location!", atNode, interpreter);
@@ -260,7 +260,7 @@ public class CollectionPlugin extends Plugin
 							
 						} else
 							capi.error("Incremental remove update only applies to modifiable enumerables." + Tools.getEOL() 
-										+ "Failed adding " + rfNode.getRemoveElement() + " to " + collectionNode.getValue() + ".", 
+										+ "Failed removing " + rfNode.getRemoveElement() + " from " + collectionNode.getValue() + " at " + collectionNode.getLocation() + ".",
 										rfNode, interpreter);
 					} else
 						capi.error("Cannot perform incremental remove update on a non-location!", rfNode, interpreter);


### PR DESCRIPTION
Sometimes I have an error message like `Failed adding foo to undef`. It's quite obvious that you cannot add something to undef; however I'm more interested in knowing on which location this happened.

This patch changes the error message to: `Failed adding foo to undef at bar(baz)`.

In the case of remove the error message seems to be copied from add without changing it's wording, that is also fixed.

Also two minor changes I made some time ago but didn't think they would be worth single PRs. I could split this PR or squash the commits if needed.