### PR TITLE
jParsec 3.0

### DIFF
--- a/org.coreasm.engine/pom.xml
+++ b/org.coreasm.engine/pom.xml
@@ -97,8 +97,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 

--- a/org.coreasm.engine/pom.xml
+++ b/org.coreasm.engine/pom.xml
@@ -119,7 +119,7 @@
 		<dependency>
 			<groupId>org.jparsec</groupId>
 			<artifactId>jparsec</artifactId>
-			<version>2.1</version>
+			<version>2.3</version>
 		</dependency>
 		<dependency>
 			<groupId>concurrent</groupId>

--- a/org.coreasm.engine/pom.xml
+++ b/org.coreasm.engine/pom.xml
@@ -119,7 +119,7 @@
 		<dependency>
 			<groupId>org.jparsec</groupId>
 			<artifactId>jparsec</artifactId>
-			<version>2.3</version>
+			<version>3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>concurrent</groupId>

--- a/org.coreasm.engine/src/org/coreasm/engine/interpreter/ScannerInfo.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/interpreter/ScannerInfo.java
@@ -15,7 +15,7 @@ package org.coreasm.engine.interpreter;
 
 import java.io.Serializable;
 
-import org.codehaus.jparsec.Token;
+import org.jparsec.Token;
 import org.coreasm.engine.Specification;
 import org.coreasm.engine.parser.CharacterPosition;
 import org.coreasm.engine.parser.Parser;

--- a/org.coreasm.engine/src/org/coreasm/engine/kernel/ExpressionParserFactory.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/kernel/ExpressionParserFactory.java
@@ -13,11 +13,11 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BinaryOperator;
+import java.util.function.UnaryOperator;
 
 import org.jparsec.OperatorTable;
 import org.jparsec.Parser;
-import org.jparsec.functors.Binary;
-import org.jparsec.functors.Unary;
 import org.coreasm.engine.ControlAPI;
 import org.coreasm.engine.EngineError;
 import org.coreasm.engine.interpreter.ASTNode;
@@ -303,7 +303,7 @@ public class ExpressionParserFactory {
 	}
 	
 	/* Special unary map class */
-	public static class UnaryMap implements Unary<Node> {
+	public static class UnaryMap implements UnaryOperator<Node> {
 		
 		//private String pluginNames;
 		private String opr;
@@ -329,7 +329,8 @@ public class ExpressionParserFactory {
 		/**
 		 * Creates a tree for this operator with an {@link ASTNode} as its root.
 		 */
-		public Node map(Node child) {
+		@Override
+		public Node apply(Node child) {
 			Node node = null;
 			if (type == OpType.POSTFIX) {
 				node = new ASTNode(
@@ -364,14 +365,15 @@ public class ExpressionParserFactory {
 			this.type = type;
 		}
 
-		public UnaryMap map(Object[] v) {
+		@Override
+		public UnaryMap apply(Object[] v) {
 			return new UnaryMap(opr, pluginName, type, v);
 		}
 		
 	}
 
 	/* Special binary map class */
-	public static class BinaryMap implements Binary<Node> {
+	public static class BinaryMap implements BinaryOperator<Node> {
 		
 		//private String pluginNames;
 		private String opr;
@@ -397,7 +399,8 @@ public class ExpressionParserFactory {
 		/**
 		 * Creates a tree for this operator with an {@link ASTNode} as its root.
 		 */
-		public Node map(Node o1, Node o2) {
+		@Override
+		public Node apply(Node o1, Node o2) {
 			Node node = new ASTNode(
 					null, ASTNode.BINARY_OPERATOR_CLASS, "", ((Node)cnodes[1]).getToken(), o1.getScannerInfo());
 			node.addChild(o1);
@@ -423,14 +426,15 @@ public class ExpressionParserFactory {
 			this.type = type;
 		}
 
-		public BinaryMap map(Object[] v) {
+		@Override
+		public BinaryMap apply(Object[] v) {
 			return new BinaryMap(opr, pluginName, type, v);
 		}
 		
 	}
 
 	/* Special index map class */
-	public static class IndexMap implements Unary<Node> {
+	public static class IndexMap implements UnaryOperator<Node> {
 		
 		//private String pluginNames;
 		private String opr1;
@@ -458,7 +462,8 @@ public class ExpressionParserFactory {
 		/**
 		 * Creates a tree for this operator with an {@link ASTNode} as its root.
 		 */
-		public Node map(Node child) {
+		@Override
+		public Node apply(Node child) {
 			Node node = null;
 			node = new ASTNode(
 					null, ASTNode.INDEX_OPERATOR_CLASS, "", opr1 + OperatorRule.OPERATOR_DELIMITER + opr2, child.getScannerInfo());
@@ -484,7 +489,8 @@ public class ExpressionParserFactory {
 			this.type = type;
 		}
 
-		public IndexMap map(Object[] v) {
+		@Override
+		public IndexMap apply(Object[] v) {
 			return new IndexMap(opr1, opr2, pluginName, type, v);
 		}
 		

--- a/org.coreasm.engine/src/org/coreasm/engine/kernel/ExpressionParserFactory.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/kernel/ExpressionParserFactory.java
@@ -14,10 +14,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.OperatorTable;
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.functors.Binary;
-import org.codehaus.jparsec.functors.Unary;
+import org.jparsec.OperatorTable;
+import org.jparsec.Parser;
+import org.jparsec.functors.Binary;
+import org.jparsec.functors.Unary;
 import org.coreasm.engine.ControlAPI;
 import org.coreasm.engine.EngineError;
 import org.coreasm.engine.interpreter.ASTNode;

--- a/org.coreasm.engine/src/org/coreasm/engine/kernel/ImportRuleParseMap.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/kernel/ImportRuleParseMap.java
@@ -31,7 +31,8 @@ public class ImportRuleParseMap extends ParseMap<Object[], Node> {
 		super(Kernel.PLUGIN_NAME);
 	}
 
-	public Node map(Object[] v) {
+	@Override
+	public Node apply(Object[] v) {
 		Node node = new ASTNode(
 				null,
 				ASTNode.RULE_CLASS,

--- a/org.coreasm.engine/src/org/coreasm/engine/kernel/Kernel.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/kernel/Kernel.java
@@ -24,8 +24,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.kernel.CompilerKernelPlugin;
 import org.coreasm.engine.ControlAPI;

--- a/org.coreasm.engine/src/org/coreasm/engine/kernel/Kernel.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/kernel/Kernel.java
@@ -314,8 +314,9 @@ public class Kernel extends Plugin
 	    			parserTools.getKeywParser("use", this.getName()),
 	    			idParser,
 	    			new ParseMap2(getName()) {
-	
-						public Node map(Node a, Node b) {
+
+	    			    @Override
+						public Node apply(Node a, Node b) {
 							Node node = new ASTNode(
 									pluginName,
 									ASTNode.DECLARATION_CLASS,
@@ -337,8 +338,9 @@ public class Kernel extends Plugin
 	    			parserTools.getKeywParser("init", this.getName()),
 	    			idParser,
 	    			new ParseMap2(getName()) {
-	
-						public Node map(Node a, Node b) {
+
+	    			    @Override
+						public Node apply(Node a, Node b) {
 							Node node = new ASTNode(
 									null,
 									null,
@@ -448,7 +450,8 @@ public class Kernel extends Plugin
     	// Rule : 'skip'
     	Parser<Node> skipRuleParser = parserTools.getKeywParser("skip", PLUGIN_NAME).map(
     			new ParseMap<Node, Node>(PLUGIN_NAME) {
-					public Node map(Node v) {
+    				@Override
+					public Node apply(Node v) {
 						return new SkipRuleNode(v.getScannerInfo());
 					}});
     	parsers.put("SkipRule", new GrammarRule("SkipRule", "'skip'", skipRuleParser, PLUGIN_NAME));
@@ -471,7 +474,8 @@ public class Kernel extends Plugin
        	Parser<Node> macroCallRule = Parsers.array(refFuncRuleTermParser.lazy()).map(
        			new ParseMap<Object[], Node>(PLUGIN_NAME) {
 
-					public Node map(Object[] vals) {
+       				@Override
+					public Node apply(Object[] vals) {
 						Node node = new MacroCallRuleNode(((Node)vals[0]).getScannerInfo());
 						node.addChild("alpha", (Node)vals[0]);
 						return node;
@@ -613,7 +617,8 @@ public class Kernel extends Plugin
     			parserTools.getKeywParser("undef", PLUGIN_NAME),
     			parserTools.getKeywParser("self", PLUGIN_NAME)).map(
     					new ParseMap<Node, Node>(PLUGIN_NAME) {
-    						public Node map(Node v) {
+    						@Override
+    						public Node apply(Node v) {
     							Node node = new ASTNode(
     									pluginName, 
     									ASTNode.EXPRESSION_CLASS, 
@@ -633,7 +638,8 @@ public class Kernel extends Plugin
     			parserTools.getKeywParser("true", PLUGIN_NAME),
     			parserTools.getKeywParser("false", PLUGIN_NAME)).map(
     					new ParseMap<Node, Node>(PLUGIN_NAME) {
-    						public Node map(Node v) {
+    						@Override
+    						public Node apply(Node v) {
     							Node node = new ASTNode(
     									pluginName, 
     									ASTNode.EXPRESSION_CLASS, 
@@ -659,7 +665,8 @@ public class Kernel extends Plugin
     					parserTools.getOprParser(")")
     					).map(new ParseMap<Object[], Node>(PLUGIN_NAME){
 
-							public Node map(Object[] v) {
+    						@Override
+							public Node apply(Object[] v) {
 								Node node = new EnclosedTermNode(((Node)v[0]).getScannerInfo());
 								for (Object o:v) node.addChild((Node)o);
 								return node;
@@ -739,7 +746,8 @@ public class Kernel extends Plugin
     			
     			new ParseMap2(PLUGIN_NAME) {
 
-					public Node map(Node a, Node b) {
+    			    @Override
+					public Node apply(Node a, Node b) {
 						Node node = new ASTNode(
 								pluginName,
 								ASTNode.EXPRESSION_CLASS,
@@ -764,7 +772,8 @@ public class Kernel extends Plugin
     			idParser,
     			new ParseMap2(PLUGIN_NAME) {
 
-					public Node map(Node a, Node d) {
+    			    @Override
+					public Node apply(Node a, Node d) {
 						Node node = new RuleOrFuncElementNode(a.getScannerInfo());
 						node.addChild(a);
 						node.addChild("alpha", d);

--- a/org.coreasm.engine/src/org/coreasm/engine/kernel/KernelServices.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/kernel/KernelServices.java
@@ -13,7 +13,7 @@
  
 package org.coreasm.engine.kernel;
 
-import org.codehaus.jparsec.Parser;
+import org.jparsec.Parser;
 
 import org.coreasm.engine.interpreter.Node;
 import org.coreasm.engine.plugin.PluginServiceInterface;

--- a/org.coreasm.engine/src/org/coreasm/engine/kernel/TupleTermParseMap.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/kernel/TupleTermParseMap.java
@@ -28,8 +28,9 @@ public class TupleTermParseMap extends ParseMap<Object[], Node> {
 	public TupleTermParseMap() {
 		super(Kernel.PLUGIN_NAME);
 	}
-	
-	public Node map(Object[] v) {
+
+	@Override
+	public Node apply(Object[] v) {
 		Node node = new ASTNode(
 				null,
 				"",

--- a/org.coreasm.engine/src/org/coreasm/engine/kernel/UpdateRuleParseMap.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/kernel/UpdateRuleParseMap.java
@@ -28,7 +28,8 @@ public class UpdateRuleParseMap extends ParseMap<Object[], Node> {
 		super(Kernel.PLUGIN_NAME);
 	}
 
-	public Node map(Object[] v) {
+	@Override
+	public Node apply(Object[] v) {
 		Node node = new UpdateRuleNode(((Node)v[0]).getScannerInfo());
 		
 		for (int i=0; i < v.length; i++) {

--- a/org.coreasm.engine/src/org/coreasm/engine/parser/GrammarProduction.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/parser/GrammarProduction.java
@@ -19,7 +19,7 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
 
-import org.codehaus.jparsec.Parser;
+import org.jparsec.Parser;
 import org.coreasm.engine.interpreter.Node;
 import org.coreasm.engine.parser.GrammarRule.GRType;
 import org.coreasm.util.CoreASMGlobal;

--- a/org.coreasm.engine/src/org/coreasm/engine/parser/GrammarRule.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/parser/GrammarRule.java
@@ -15,10 +15,10 @@ package org.coreasm.engine.parser;
 
 import org.coreasm.engine.interpreter.Node;
 
-import org.codehaus.jparsec.Parser;
+import org.jparsec.Parser;
 
 /** 
- * A structure to hold a grammar rule, and a {@link jfun.parsec.Parser} instance
+ * A structure to hold a grammar rule, and a {@link org.jparsec.Parser} instance
  * for that grammar rule.
  *   
  * @author Roozbeh Farahbod

--- a/org.coreasm.engine/src/org/coreasm/engine/parser/JParsecParser.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/parser/JParsecParser.java
@@ -57,7 +57,7 @@ public class JParsecParser implements Parser {
 	private boolean headerParsed = false;
 	
 	/** the actual parser -- a JParsec parser */ 
-	private org.codehaus.jparsec.Parser<Node> parser;
+	private org.jparsec.Parser<Node> parser;
 	
 	/** the root grammar rule */
 	private GrammarRule rootGrammarRule;
@@ -167,11 +167,11 @@ public class JParsecParser implements Parser {
 				this.rootGrammarRule = ((ParserPlugin)kernel).getParsers().get("CoreASM");
 				this.parser = rootGrammarRule.parser;
 				try {
-					org.codehaus.jparsec.Parser<Node> _parser =  parser.from(parserTools.getTokenizer(), parserTools.getIgnored());
+					org.jparsec.Parser<Node> _parser =  parser.from(parserTools.getTokenizer(), parserTools.getIgnored());
 					rootNode = (ASTNode) _parser.parse(specification.getText());
 				} catch (Throwable e) {
-					if (e instanceof org.codehaus.jparsec.error.ParserException) {
-						org.codehaus.jparsec.error.ParserException pe = (org.codehaus.jparsec.error.ParserException) e;
+					if (e instanceof org.jparsec.error.ParserException) {
+						org.jparsec.error.ParserException pe = (org.jparsec.error.ParserException) e;
 						Throwable cause = pe.getCause();
 						String msg = pe.getMessage();
 						msg = msg.substring(msg.indexOf("\n")+1);

--- a/org.coreasm.engine/src/org/coreasm/engine/parser/ParseMap.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/parser/ParseMap.java
@@ -15,16 +15,16 @@ package org.coreasm.engine.parser;
 
 import org.coreasm.engine.plugin.Plugin;
 
-import org.jparsec.functors.Map;
+import java.util.function.Function;
 
 /** 
- * Specialized version of {@link Map} that gets a plug-in name as well. 
+ * Specialized version that gets a plug-in name as well.
  *   
  * @author Roozbeh Farahbod
  * 
  */
 
-public abstract class ParseMap<To, From> implements Map<To, From> {
+public abstract class ParseMap<To, From> implements Function<To, From> {
 
 	public final String pluginName;
 	

--- a/org.coreasm.engine/src/org/coreasm/engine/parser/ParseMap.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/parser/ParseMap.java
@@ -15,7 +15,7 @@ package org.coreasm.engine.parser;
 
 import org.coreasm.engine.plugin.Plugin;
 
-import org.codehaus.jparsec.functors.Map;
+import org.jparsec.functors.Map;
 
 /** 
  * Specialized version of {@link Map} that gets a plug-in name as well. 

--- a/org.coreasm.engine/src/org/coreasm/engine/parser/ParseMap2.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/parser/ParseMap2.java
@@ -3,7 +3,7 @@ package org.coreasm.engine.parser;
 import org.coreasm.engine.interpreter.Node;
 import org.coreasm.engine.plugin.Plugin;
 
-import org.codehaus.jparsec.functors.Map2;
+import org.jparsec.functors.Map2;
 
 /** 
  * Specialized version of {@link Map3} that gets a plug-in name as well. 

--- a/org.coreasm.engine/src/org/coreasm/engine/parser/ParseMap2.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/parser/ParseMap2.java
@@ -3,16 +3,16 @@ package org.coreasm.engine.parser;
 import org.coreasm.engine.interpreter.Node;
 import org.coreasm.engine.plugin.Plugin;
 
-import org.jparsec.functors.Map2;
+import java.util.function.BiFunction;
 
 /** 
- * Specialized version of {@link Map3} that gets a plug-in name as well. 
+ * Specialized version that gets a plug-in name as well.
  *   
  * @author Roozbeh Farahbod
  * 
  */
 
-public abstract class ParseMap2 implements Map2<Node, Node, Node> {
+public abstract class ParseMap2 implements BiFunction<Node, Node, Node> {
 
 	public final String pluginName;
 	

--- a/org.coreasm.engine/src/org/coreasm/engine/parser/ParseMap3.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/parser/ParseMap3.java
@@ -16,7 +16,7 @@ package org.coreasm.engine.parser;
 import org.coreasm.engine.interpreter.Node;
 import org.coreasm.engine.plugin.Plugin;
 
-import org.codehaus.jparsec.functors.Map3;
+import org.jparsec.functors.Map3;
 
 /** 
  * Specialized version of {@link Map3} that gets a plug-in name as well. 

--- a/org.coreasm.engine/src/org/coreasm/engine/parser/ParseMap5.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/parser/ParseMap5.java
@@ -13,7 +13,7 @@
  
 package org.coreasm.engine.parser;
 
-import org.codehaus.jparsec.functors.Map5;
+import org.jparsec.functors.Map5;
 import org.coreasm.engine.interpreter.Node;
 import org.coreasm.engine.plugin.Plugin;
 

--- a/org.coreasm.engine/src/org/coreasm/engine/parser/ParserException.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/parser/ParserException.java
@@ -48,10 +48,10 @@ public class ParserException extends EngineException {
 	}
 	
 	public ParserException(Throwable cause) {
-		if (cause instanceof org.codehaus.jparsec.error.ParserException) {
-			org.codehaus.jparsec.error.ParserException pcause = (org.codehaus.jparsec.error.ParserException) cause;
+		if (cause instanceof org.jparsec.error.ParserException) {
+			org.jparsec.error.ParserException pcause = (org.jparsec.error.ParserException) cause;
 			StringBuffer buf = new StringBuffer();
-			org.codehaus.jparsec.error.ParseErrorDetails err = pcause.getErrorDetails();
+			org.jparsec.error.ParseErrorDetails err = pcause.getErrorDetails();
 			if (err != null) {
 		        showExpecting(buf, err.getExpected().toArray(new String[] {} ));
 		        showUnexpected(buf, new String[] {err.getUnexpected()} );

--- a/org.coreasm.engine/src/org/coreasm/engine/parser/ParserTools.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/parser/ParserTools.java
@@ -2,13 +2,13 @@ package org.coreasm.engine.parser;
 
 import java.util.*;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
-import org.codehaus.jparsec.Scanners;
-import org.codehaus.jparsec.Terminals;
-import org.codehaus.jparsec.Token;
-import org.codehaus.jparsec.Tokens.Fragment;
-import org.codehaus.jparsec.functors.Map;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
+import org.jparsec.Scanners;
+import org.jparsec.Terminals;
+import org.jparsec.Token;
+import org.jparsec.Tokens.Fragment;
+import org.jparsec.functors.Map;
 import org.coreasm.engine.ControlAPI;
 import org.coreasm.engine.EngineError;
 import org.coreasm.engine.interpreter.ASTNode;

--- a/org.coreasm.engine/src/org/coreasm/engine/parser/ParserTools.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/parser/ParserTools.java
@@ -1,9 +1,6 @@
 package org.coreasm.engine.parser;
 
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.codehaus.jparsec.Parser;
 import org.codehaus.jparsec.Parsers;
@@ -59,7 +56,7 @@ public class ParserTools
 		initialized = false;
 	}
 	
-	public void init(String [] keywords, String[] operators, Set<Parser<? extends Object>> lexers)
+	public void init(String [] keywords, String[] ops, Set<Parser<? extends Object>> lexers)
 	{
 		if (initialized == true)
 			throw new EngineError("Cannot re-initialize ParserTools.");
@@ -67,7 +64,7 @@ public class ParserTools
 		keywParsers = new HashMap<String, Parser<Node>>();
 		oprParsers = new HashMap<String, Parser<Node>>();
 		
-		terminals_keyw = Terminals.caseSensitive(operators, keywords);
+		terminals_keyw = Terminals.operators(ops).words(Scanners.IDENTIFIER).keywords(Arrays.asList(keywords)).build();
 		tokenizer_keyw = terminals_keyw.tokenizer();
 		tokenizer_id = Terminals.Identifier.TOKENIZER;
 		

--- a/org.coreasm.engine/src/org/coreasm/engine/parser/_.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/parser/_.java
@@ -1,5 +1,0 @@
-package org.coreasm.engine.parser;
-
-public class _ {
-
-}

--- a/org.coreasm.engine/src/org/coreasm/engine/plugin/ParserPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugin/ParserPlugin.java
@@ -16,7 +16,7 @@ package org.coreasm.engine.plugin;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
+import org.jparsec.Parser;
 import org.coreasm.engine.interpreter.Node;
 import org.coreasm.engine.parser.GrammarRule;
 

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/abstraction/AbstractionPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/abstraction/AbstractionPlugin.java
@@ -116,7 +116,7 @@ public class AbstractionPlugin extends Plugin
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
 						@Override
-						public Node map(Object[] vals) {
+						public Node apply(Object[] vals) {
 							Node node = new AbstractRuleNode(((Node)vals[0]).getScannerInfo());
 							node.addChild((Node) vals[0]);
 							node.addChild("alpha", (Node)vals[1]);

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/abstraction/AbstractionPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/abstraction/AbstractionPlugin.java
@@ -19,8 +19,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.abstraction.CompilerAbstractionPlugin;
 import org.coreasm.engine.VersionInfo;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/activation/ActivationPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/activation/ActivationPlugin.java
@@ -5,8 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.options.CompilerOptionsPlugin;
 import org.coreasm.engine.CoreASMError;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/activation/ActivationPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/activation/ActivationPlugin.java
@@ -141,7 +141,8 @@ public class ActivationPlugin extends Plugin implements ParserPlugin, Interprete
 			Parser<Node> activateParser = Parsers
 					.array(new Parser[] { pTools.getKeywParser("activate", PLUGIN_NAME), funcRuleTermParser })
 					.map(new ParserTools.ArrayParseMap(PLUGIN_NAME) {
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new ActivationNode(((Node) vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;
@@ -150,7 +151,8 @@ public class ActivationPlugin extends Plugin implements ParserPlugin, Interprete
 			Parser<Node> deactivateParser = Parsers
 					.array(new Parser[] { pTools.getKeywParser("deactivate", PLUGIN_NAME), funcRuleTermParser })
 					.map(new ParserTools.ArrayParseMap(PLUGIN_NAME) {
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new ActivationNode(((Node) vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/bag/BagPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/bag/BagPlugin.java
@@ -25,8 +25,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.engine.EngineError;
 import org.coreasm.engine.EngineException;
 import org.coreasm.engine.VersionInfo;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/bag/BagPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/bag/BagPlugin.java
@@ -1087,8 +1087,9 @@ public class BagPlugin extends Plugin
 		public BagEnumerateParseMap() {
 			super(PLUGIN_NAME);
 		}
-		
-		public Node map(Object[] vals) {
+
+		@Override
+		public Node apply(Object[] vals) {
 			Node node = new BagEnumerateNode(((Node)vals[0]).getScannerInfo());
 			addChildren(node, vals);
 			return node;
@@ -1101,8 +1102,9 @@ public class BagPlugin extends Plugin
 		public BagComprehensionParseMap() {
 			super(PLUGIN_NAME);
 		}
-		
-		public Node map(Object[] vals) {
+
+		@Override
+		public Node apply(Object[] vals) {
 			Node node = null;
 			// if there is an 'is' clause
 			if (vals[1] != null && vals[1] instanceof Object[]) {

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/blockrule/BlockRulePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/blockrule/BlockRulePlugin.java
@@ -149,7 +149,7 @@ public class BlockRulePlugin extends Plugin
 					).map(new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
 						@Override
-						public Node map(Object[] from) {
+						public Node apply(Object[] from) {
 							ASTNode node = new ASTNode(
 									BlockRulePlugin.PLUGIN_NAME,
 									ASTNode.RULE_CLASS,

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/blockrule/BlockRulePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/blockrule/BlockRulePlugin.java
@@ -19,8 +19,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.blockrule.CompilerBlockRulePlugin;
 import org.coreasm.engine.EngineTools;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/caserule/CaseRulePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/caserule/CaseRulePlugin.java
@@ -20,8 +20,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.caserule.CompilerCaseRulePlugin;
 import org.coreasm.engine.VersionInfo;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/caserule/CaseRulePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/caserule/CaseRulePlugin.java
@@ -197,7 +197,8 @@ public class CaseRulePlugin extends Plugin
 			super(PLUGIN_NAME);
 		}
 
-		public Node map(Object[] vals) {
+		@Override
+		public Node apply(Object[] vals) {
 			nextChildName = "alpha";
             Node node = new CaseRuleNode(((Node)vals[0]).getScannerInfo());
             addChildren(node, vals);

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/chooserule/ChooseRulePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/chooserule/ChooseRulePlugin.java
@@ -24,8 +24,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.chooserule.CompilerChooseRulePlugin;
 import org.coreasm.engine.ControlAPI;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/chooserule/ChooseRulePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/chooserule/ChooseRulePlugin.java
@@ -164,7 +164,8 @@ public class ChooseRulePlugin extends Plugin implements ParserPlugin,
 								termParser).optional()
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
-						public Node map(Object[] vals) {
+					    @Override
+						public Node apply(Object[] vals) {
 							Node node = new PickExpNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;
@@ -729,8 +730,9 @@ public class ChooseRulePlugin extends Plugin implements ParserPlugin,
 	    public ChooseParseMap() {
 			super(PLUGIN_NAME);
 		}
-		
-		public Node map(Object[] v) {
+
+		@Override
+		public Node apply(Object[] v) {
 			nextChildName = "alpha";
 			ASTNode node = new ChooseRuleNode(((Node)v[0]).getScannerInfo());
 

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/collection/CollectionPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/collection/CollectionPlugin.java
@@ -136,7 +136,8 @@ public class CollectionPlugin extends Plugin
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new AddToRuleNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;
@@ -156,7 +157,8 @@ public class CollectionPlugin extends Plugin
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new RemoveFromRuleNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/collection/CollectionPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/collection/CollectionPlugin.java
@@ -19,8 +19,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.collection.CompilerCollectionPlugin;
 import org.coreasm.engine.CoreASMError;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/conditionalrule/ConditionalRulePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/conditionalrule/ConditionalRulePlugin.java
@@ -17,8 +17,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.conditionalrule.CompilerConditionalRulePlugin;
 import org.coreasm.engine.CoreASMError;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/conditionalrule/ConditionalRulePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/conditionalrule/ConditionalRulePlugin.java
@@ -188,12 +188,13 @@ public class ConditionalRulePlugin extends Plugin
 					termParser,
 					pTools.getKeywParser("else", PLUGIN_NAME),
 					termParser).map(new ArrayParseMap(PLUGIN_NAME) {
-				public Node map(Object[] vals) {
-					Node node = new ConditionalTermNode(((Node)vals[0]).getScannerInfo());
-					addChildren(node, vals);
-					return node;
-				}
-			});
+						@Override
+						public Node apply(Object[] vals) {
+							Node node = new ConditionalTermNode(((Node)vals[0]).getScannerInfo());
+							addChildren(node, vals);
+							return node;
+						}
+					});
 			parsers.put("BasicTerm", new GrammarRule("ConditionalTerm", "'if' Term 'then' Term 'else' Term",
 					condTermParser, PLUGIN_NAME));
 
@@ -225,7 +226,7 @@ public class ConditionalRulePlugin extends Plugin
 		}
 
 		@Override
-		public Node map(Object[] vals) {
+		public Node apply(Object[] vals) {
 			nextChildName = "guard";
 			Node node = new ConditionalRuleNode(((Node) vals[0]).getScannerInfo());
 			addChildren(node, vals);

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/debuginfo/DebugInfoPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/debuginfo/DebugInfoPlugin.java
@@ -24,8 +24,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.engine.VersionInfo;
 import org.coreasm.engine.absstorage.UpdateMultiset;
 import org.coreasm.engine.interpreter.ASTNode;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/debuginfo/DebugInfoPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/debuginfo/DebugInfoPlugin.java
@@ -163,7 +163,8 @@ public class DebugInfoPlugin extends Plugin implements ParserPlugin, Interpreter
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new DebugInfoNode(((Node)vals[0]).getScannerInfo());
 							node.addChild((Node)vals[0]);
 							node.addChild("alpha", (Node)vals[1]);

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/extendrule/ExtendRulePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/extendrule/ExtendRulePlugin.java
@@ -179,7 +179,8 @@ public class ExtendRulePlugin extends Plugin implements ParserPlugin, Interprete
 			super(PLUGIN_NAME);
 		}
 
-		public Node map(Object[] vals) {
+		@Override
+		public Node apply(Object[] vals) {
 			Node node = new ExtendRuleNode(((Node)vals[0]).getScannerInfo());
 			addChildren(node, vals);
 			return node;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/extendrule/ExtendRulePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/extendrule/ExtendRulePlugin.java
@@ -18,8 +18,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.extendrule.CompilerExtendRulePlugin;
 import org.coreasm.engine.VersionInfo;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/forallrule/ForallRulePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/forallrule/ForallRulePlugin.java
@@ -323,7 +323,8 @@ public class ForallRulePlugin extends Plugin implements ParserPlugin,
 			super(PLUGIN_NAME);
 		}
 
-		public Node map(Object[] vals) {
+		@Override
+		public Node apply(Object[] vals) {
 			nextChildName = "alpha";
             Node node = new ForallRuleNode(((Node)vals[0]).getScannerInfo());
             addChildren(node, vals);

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/forallrule/ForallRulePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/forallrule/ForallRulePlugin.java
@@ -22,8 +22,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.forall.CompilerForallRulePlugin;
 import org.coreasm.engine.CoreASMError;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/foreachrule/ForeachRulePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/foreachrule/ForeachRulePlugin.java
@@ -8,8 +8,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.engine.CoreASMError;
 import org.coreasm.engine.VersionInfo;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/foreachrule/ForeachRulePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/foreachrule/ForeachRulePlugin.java
@@ -313,7 +313,8 @@ public class ForeachRulePlugin extends Plugin implements ParserPlugin,
 			super(PLUGIN_NAME);
 		}
 
-		public Node map(Object[] vals) {
+		@Override
+		public Node apply(Object[] vals) {
 			nextChildName = "alpha";
             Node node = new ForeachRuleNode(((Node)vals[0]).getScannerInfo());
             addChildren(node, vals);

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/io/IOPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/io/IOPlugin.java
@@ -230,23 +230,21 @@ public class IOPlugin extends Plugin implements
 											npTools.getKeywParser(KEYWORD_INTO, PLUGIN_NAME),
 											npTools.getOprParser(OPERATOR_LINUX_INTO)),
 									termParser).optional()
-					}).map(new org.jparsec.functors.Map<Object[], Node>() {
-						public Node map(Object[] vals) {
-							if (vals[2] == null) {
-								Node node = new PrintRuleNode(((Node) vals[0]).getScannerInfo());
-								node.addChild((Node) vals[0]);
-								node.addChild("alpha", (Node) vals[1]);
-								return node;
-							}
-							Node node = new PrintToFileRuleNode(((Node) vals[0]).getScannerInfo());
-							node.addChild((Node) vals[0]);
-							node.addChild("alpha", (Node) vals[1]);
-							Object[] toPart = (Object[]) vals[2];
-							node.addChild((Node) toPart[0]);
-							node.addChild("beta", (Node) toPart[1]);
-							return node;
-						}
-					});
+					}).map(vals -> {
+                        if (vals[2] == null) {
+                            Node node = new PrintRuleNode(((Node) vals[0]).getScannerInfo());
+                            node.addChild((Node) vals[0]);
+                            node.addChild("alpha", (Node) vals[1]);
+                            return node;
+                        }
+                        Node node = new PrintToFileRuleNode(((Node) vals[0]).getScannerInfo());
+                        node.addChild((Node) vals[0]);
+                        node.addChild("alpha", (Node) vals[1]);
+                        Object[] toPart = (Object[]) vals[2];
+                        node.addChild((Node) toPart[0]);
+                        node.addChild("beta", (Node) toPart[1]);
+                        return node;
+                    });
 
 
 			parsers.put("Rule",

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/io/IOPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/io/IOPlugin.java
@@ -28,8 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.io.CompilerIOPlugin;
 import org.coreasm.engine.CoreASMEngine.EngineMode;
@@ -230,7 +230,7 @@ public class IOPlugin extends Plugin implements
 											npTools.getKeywParser(KEYWORD_INTO, PLUGIN_NAME),
 											npTools.getOprParser(OPERATOR_LINUX_INTO)),
 									termParser).optional()
-					}).map(new org.codehaus.jparsec.functors.Map<Object[], Node>() {
+					}).map(new org.jparsec.functors.Map<Object[], Node>() {
 						public Node map(Object[] vals) {
 							if (vals[2] == null) {
 								Node node = new PrintRuleNode(((Node) vals[0]).getScannerInfo());

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/kernelextensions/KernelExtensionsPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/kernelextensions/KernelExtensionsPlugin.java
@@ -143,7 +143,8 @@ public class KernelExtensionsPlugin extends Plugin implements ParserPlugin, Inte
        				tupleTermParser
        				}).map( new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+       					@Override
+						public Node apply(Object[] vals) {
 							Node node = new ExtendedFunctionRuleTermNode(((Node)vals[0]).getScannerInfo());
 							addChild(node, (new FunctionRuleTermParseMap()).map((Node)vals[0], (Node)vals[1]));
 							for (Node n: ((Node)vals[2]).getChildNodes())
@@ -164,7 +165,8 @@ public class KernelExtensionsPlugin extends Plugin implements ParserPlugin, Inte
        				pTools.getOprParser(")"),
        				tupleTermParser
        				}).map( new ParserTools.ArrayParseMap(PLUGIN_NAME) {
-						public Node map(Object[] vals) {
+       					@Override
+						public Node apply(Object[] vals) {
 							Node node = new ExtendedFunctionRuleTermNode(((Node)vals[0]).getScannerInfo());
 							for (int i = 0; i < 3; i++)
 								if (vals[i] != null)
@@ -190,7 +192,8 @@ public class KernelExtensionsPlugin extends Plugin implements ParserPlugin, Inte
 					}).map( 
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new ExtendedRuleCallNode(((Node)vals[0]).getScannerInfo());
 							addChild(node, (Node)vals[0]);
 							for (NameNodeTuple nt: ((Node)vals[1]).getChildNodesWithNames())

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/kernelextensions/KernelExtensionsPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/kernelextensions/KernelExtensionsPlugin.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.kernelextensions.CompilerKernelExtensionsPlugin;
 import org.coreasm.engine.EngineTools;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/letrule/LetRulePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/letrule/LetRulePlugin.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.letrule.CompilerLetRulePlugin;
 import org.coreasm.engine.CoreASMError;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/letrule/LetRulePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/letrule/LetRulePlugin.java
@@ -313,8 +313,9 @@ public class LetRulePlugin extends Plugin implements ParserPlugin, InterpreterPl
 		}
 
 		String nextChildName = "alpha";
-		
-		public Node map(Object[] vals) {
+
+		@Override
+		public Node apply(Object[] vals) {
 			nextChildName = "alpha";
 			LetRuleNode node = new LetRuleNode(((Node)vals[0]).getScannerInfo());
 			if (vals[1] instanceof Object[] && ((Object[])vals[1])[0] instanceof Node) {

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/list/ListPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/list/ListPlugin.java
@@ -237,7 +237,7 @@ public class ListPlugin extends Plugin implements ParserPlugin,
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
 						@Override
-						public Node map(Object[] vals) {
+						public Node apply(Object[] vals) {
 							Node node = new ListTermNode();
 							addChildren(node, vals);
 							node.setScannerInfo(node.getFirstCSTNode());
@@ -274,7 +274,7 @@ public class ListPlugin extends Plugin implements ParserPlugin,
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
 						@Override
-						public Node map(Object[] vals) {
+						public Node apply(Object[] vals) {
 							boolean isLeft = ((Node)vals[1]).getToken().equals("left");
 							Node node = new ShiftRuleNode(((Node)vals[0]).getScannerInfo(), isLeft);
 							addChildren(node, vals);
@@ -717,8 +717,9 @@ public class ListPlugin extends Plugin implements ParserPlugin,
 		public ListComprehensionParseMap() {
 			super(PLUGIN_NAME);
 		}
-		
-		public Node map(Object[] vals) {
+
+		@Override
+		public Node apply(Object[] vals) {
 			Node node = new ListCompNode(((Node)vals[0]).getScannerInfo());
 			addChildren(node, vals);
 			return node;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/list/ListPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/list/ListPlugin.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.list.CompilerListPlugin;
 import org.coreasm.engine.EngineException;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/map/MapPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/map/MapPlugin.java
@@ -185,7 +185,7 @@ public class MapPlugin extends Plugin implements ParserPlugin, InterpreterPlugin
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
 						@Override
-						public Node map(Object[] vals) {
+						public Node apply(Object[] vals) {
 							ASTNode node = new MapletNode((Node)vals[0]);
 							addChildren(node, vals);
 							return node;
@@ -205,7 +205,7 @@ public class MapPlugin extends Plugin implements ParserPlugin, InterpreterPlugin
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
 						@Override
-						public Node map(Object[] vals) {
+						public Node apply(Object[] vals) {
 							Node node = new MapTermNode((Node)vals[0]);
 							addChildren(node, vals);
 							return node;
@@ -537,8 +537,9 @@ public class MapPlugin extends Plugin implements ParserPlugin, InterpreterPlugin
 		public MapComprehensionParseMap() {
 			super(PLUGIN_NAME);
 		}
-		
-		public Node map(Object[] vals) {
+
+		@Override
+		public Node apply(Object[] vals) {
 			Node node = new MapCompNode(((Node)vals[0]).getScannerInfo());
 			addChildren(node, vals);
 			return node;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/map/MapPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/map/MapPlugin.java
@@ -21,8 +21,8 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.map.CompilerMapPlugin;
 import org.coreasm.engine.EngineException;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/math/MathPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/math/MathPlugin.java
@@ -19,7 +19,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
+import org.jparsec.Parser;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.math.CompilerMathPlugin;
 import org.coreasm.engine.VersionInfo;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/math/MathPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/math/MathPlugin.java
@@ -194,7 +194,8 @@ public class MathPlugin extends Plugin implements VocabularyExtender, ParserPlug
 					pTools.getKeywParser(KW_RANDOM_VALUE, PLUGIN_NAME).map(
 					new ParseMap<Node, Node>(PLUGIN_NAME) {
 
-						public Node map(Node v) {
+						@Override
+						public Node apply(Node v) {
 							Node node = new ASTNode(
 									PLUGIN_NAME, 
 									ASTNode.EXPRESSION_CLASS, 

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/modularity/CoreModuleParseMap.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/modularity/CoreModuleParseMap.java
@@ -29,8 +29,9 @@ public class CoreModuleParseMap extends ParserTools.ArrayParseMap {
 	public CoreModuleParseMap() {
 		super(ModularityPlugin.PLUGIN_NAME);
 	}
-	
-	public Node map(Object[] vals) {
+
+	@Override
+	public Node apply(Object[] vals) {
 		ScannerInfo info = null;
 		
 		// consider the possibility of starting with a 

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/modularity/ModularityPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/modularity/ModularityPlugin.java
@@ -188,7 +188,7 @@ public class ModularityPlugin extends Plugin implements ParserPlugin,
 					stringParser
 			}).map( new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 				@Override
-				public Node map(Object[] from) {
+				public Node apply(Object[] from) {
 					int index = -1;
 					if (from[0]!=null && from[0] instanceof Token)
 						index = ((Token)from[0]).index();

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/modularity/ModularityPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/modularity/ModularityPlugin.java
@@ -26,9 +26,9 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
-import org.codehaus.jparsec.Token;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
+import org.jparsec.Token;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.modularity.CompilerModularityPlugin;
 import org.coreasm.engine.CoreASMEngine.EngineMode;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/number/NumberPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/number/NumberPlugin.java
@@ -263,7 +263,7 @@ public class NumberPlugin extends Plugin implements ParserPlugin,
 			
 			Pattern pDigits = Patterns.range('0', '9').many1();
 			Pattern pFloat = pDigits.next(Patterns.isChar('.').next(pDigits).optional());
-			Parser<String> sFloat = Scanners.pattern(pFloat, "NUMBER").source();
+			Parser<String> sFloat = pFloat.toScanner("NUMBER").source();
 			tokenizer_nr = sFloat.map(
 				new org.codehaus.jparsec.functors.Map<String,Fragment>() {
 					@Override

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/number/NumberPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/number/NumberPlugin.java
@@ -20,16 +20,16 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
-import org.codehaus.jparsec.Scanners;
-import org.codehaus.jparsec.Terminals;
-import org.codehaus.jparsec.Token;
-import org.codehaus.jparsec.Tokens;
-import org.codehaus.jparsec.Tokens.Fragment;
-import org.codehaus.jparsec.Tokens.Tag;
-import org.codehaus.jparsec.pattern.Pattern;
-import org.codehaus.jparsec.pattern.Patterns;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
+import org.jparsec.Scanners;
+import org.jparsec.Terminals;
+import org.jparsec.Token;
+import org.jparsec.Tokens;
+import org.jparsec.Tokens.Fragment;
+import org.jparsec.Tokens.Tag;
+import org.jparsec.pattern.Pattern;
+import org.jparsec.pattern.Patterns;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.number.CompilerNumberPlugin;
 import org.coreasm.engine.ControlAPI;
@@ -265,7 +265,7 @@ public class NumberPlugin extends Plugin implements ParserPlugin,
 			Pattern pFloat = pDigits.next(Patterns.isChar('.').next(pDigits).optional());
 			Parser<String> sFloat = pFloat.toScanner("NUMBER").source();
 			tokenizer_nr = sFloat.map(
-				new org.codehaus.jparsec.functors.Map<String,Fragment>() {
+				new org.jparsec.functors.Map<String,Fragment>() {
 					@Override
 					public Fragment map(String from) {
 						return Tokens.fragment(from, Tag.DECIMAL);
@@ -358,7 +358,7 @@ public class NumberPlugin extends Plugin implements ParserPlugin,
 	
 		if (refNumberTermParser.get() == null) {
 			Parser<Node> nrParser = Terminals.fragment(Tag.DECIMAL).token().map(
-				new org.codehaus.jparsec.functors.Map<Token,Node> () {
+				new org.jparsec.functors.Map<Token,Node> () {
 					@Override
 					public Node map(Token from) {
 						return new NumberTermNode(new ScannerInfo(from), from.toString());

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/number/NumberPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/number/NumberPlugin.java
@@ -264,14 +264,7 @@ public class NumberPlugin extends Plugin implements ParserPlugin,
 			Pattern pDigits = Patterns.range('0', '9').many1();
 			Pattern pFloat = pDigits.next(Patterns.isChar('.').next(pDigits).optional());
 			Parser<String> sFloat = pFloat.toScanner("NUMBER").source();
-			tokenizer_nr = sFloat.map(
-				new org.jparsec.functors.Map<String,Fragment>() {
-					@Override
-					public Fragment map(String from) {
-						return Tokens.fragment(from, Tag.DECIMAL);
-					}				
-				}
-			);
+			tokenizer_nr = sFloat.map(from -> Tokens.fragment(from, Tag.DECIMAL));
 			lexers.add(tokenizer_nr);
 		}
 		return lexers;
@@ -311,7 +304,8 @@ public class NumberPlugin extends Plugin implements ParserPlugin,
 								termParser).optional(),
 						pTools.getOprParser("]")
 					}).map(new ParserTools.ArrayParseMap(PLUGIN_NAME) {
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new NumberRangeNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;
@@ -330,7 +324,8 @@ public class NumberPlugin extends Plugin implements ParserPlugin,
 						termParser,
 						pTools.getOprParser("|")
 					}).map(new ParserTools.ArrayParseMap(PLUGIN_NAME) {
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new SizeOfEnumNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;
@@ -358,12 +353,7 @@ public class NumberPlugin extends Plugin implements ParserPlugin,
 	
 		if (refNumberTermParser.get() == null) {
 			Parser<Node> nrParser = Terminals.fragment(Tag.DECIMAL).token().map(
-				new org.jparsec.functors.Map<Token,Node> () {
-					@Override
-					public Node map(Token from) {
-						return new NumberTermNode(new ScannerInfo(from), from.toString());
-					}
-				}
+					from -> new NumberTermNode(new ScannerInfo(from), from.toString())
 			);
 			refNumberTermParser.set(nrParser);
 		}

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/options/OptionsPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/options/OptionsPlugin.java
@@ -18,8 +18,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.options.CompilerOptionsPlugin;
 import org.coreasm.engine.CoreASMEngine.EngineMode;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/options/OptionsPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/options/OptionsPlugin.java
@@ -143,7 +143,8 @@ public class OptionsPlugin extends Plugin implements ParserPlugin,
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							String str = objectToString(vals);
 							return new ASTNode(
 									PLUGIN_NAME,
@@ -194,7 +195,8 @@ public class OptionsPlugin extends Plugin implements ParserPlugin,
 				}).map(
 				new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-					public Node map(Object[] vals) {
+					@Override
+					public Node apply(Object[] vals) {
 						Node node = new OptionNode(((Node)vals[0]).getScannerInfo());
 						addChildren(node, vals);
 						return node;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/plotter/PlotterPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/plotter/PlotterPlugin.java
@@ -149,7 +149,8 @@ public class PlotterPlugin extends Plugin implements
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new PlotRuleNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/plotter/PlotterPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/plotter/PlotterPlugin.java
@@ -19,8 +19,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.engine.CoreASMEngine.EngineMode;
 import org.coreasm.engine.VersionInfo;
 import org.coreasm.engine.absstorage.BackgroundElement;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/predicatelogic/PredicateLogicPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/predicatelogic/PredicateLogicPlugin.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.predicatelogic.CompilerPredicateLogicPlugin;
 import org.coreasm.engine.CoreASMError;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/predicatelogic/PredicateLogicPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/predicatelogic/PredicateLogicPlugin.java
@@ -319,7 +319,8 @@ public class PredicateLogicPlugin extends Plugin implements OperatorProvider, Pa
 						termParser
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new ForallExpNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;
@@ -340,7 +341,8 @@ public class PredicateLogicPlugin extends Plugin implements OperatorProvider, Pa
 						termParser
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new ExistsExpNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/property/PropertyPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/property/PropertyPlugin.java
@@ -170,8 +170,9 @@ public class PropertyPlugin extends Plugin implements ParserPlugin, OperatorProv
  		public PropertyParseMap() {
  			super(PLUGIN_NAME);
  		}
- 		
- 		public Node map(Object[] vals) {
+
+ 		@Override
+ 		public Node apply(Object[] vals) {
 	        PropertyListNode node = new PropertyListNode(null);
 	        addChildren(node, vals);
 	        node.setScannerInfo(node.getFirstCSTNode());

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/property/PropertyPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/property/PropertyPlugin.java
@@ -21,8 +21,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.engine.VersionInfo;
 import org.coreasm.engine.absstorage.Element;
 import org.coreasm.engine.interpreter.ASTNode;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/queue/QueuePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/queue/QueuePlugin.java
@@ -114,7 +114,8 @@ public class QueuePlugin extends Plugin implements ParserPlugin,
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new EnqueueRuleNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;
@@ -134,7 +135,8 @@ public class QueuePlugin extends Plugin implements ParserPlugin,
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new DequeueRuleNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/queue/QueuePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/queue/QueuePlugin.java
@@ -19,8 +19,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.engine.VersionInfo;
 import org.coreasm.engine.absstorage.Element;
 import org.coreasm.engine.absstorage.Update;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/schedulingpolicies/SchedulingPoliciesPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/schedulingpolicies/SchedulingPoliciesPlugin.java
@@ -22,8 +22,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.engine.CoreASMEngine.EngineMode;
 import org.coreasm.engine.CoreASMError;
 import org.coreasm.engine.CoreASMIssue;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/schedulingpolicies/SchedulingPoliciesPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/schedulingpolicies/SchedulingPoliciesPlugin.java
@@ -203,7 +203,8 @@ public class SchedulingPoliciesPlugin extends Plugin implements
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+					    @Override
+						public Node apply(Object[] vals) {
 							Node node = new AgentManagementRuleNode(((Node)vals[0]).getScannerInfo(), "SuspendAgentRule");
 							node.addChild((Node)vals[0]);
 							node.addChild("alpha", (Node)vals[1]);
@@ -220,7 +221,8 @@ public class SchedulingPoliciesPlugin extends Plugin implements
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+					    @Override
+						public Node apply(Object[] vals) {
 							Node node = new AgentManagementRuleNode(((Node)vals[0]).getScannerInfo(), "ResumeAgentRule");
 							node.addChild((Node)vals[0]);
 							node.addChild("alpha", (Node)vals[1]);
@@ -237,7 +239,8 @@ public class SchedulingPoliciesPlugin extends Plugin implements
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+					    @Override
+						public Node apply(Object[] vals) {
 							Node node = new AgentManagementRuleNode(((Node)vals[0]).getScannerInfo(), "TerminateAgentRule");
 							node.addChild((Node)vals[0]);
 							node.addChild("alpha", (Node)vals[1]);
@@ -251,7 +254,8 @@ public class SchedulingPoliciesPlugin extends Plugin implements
 					pTools.getKeywParser(SHUTDOWN_KEYWORD, PLUGIN_NAME).map(
 					new ParseMap<Node, Node>(PLUGIN_NAME) {
 
-						public Node map(Node v) {
+					    @Override
+						public Node apply(Node v) {
 							Node node = new AgentManagementRuleNode(v.getScannerInfo(), "ShutdownRule");
 							node.addChild(v);
 							return node;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/set/SetPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/set/SetPlugin.java
@@ -1143,8 +1143,9 @@ public class SetPlugin extends Plugin
 		public SetEnumerateParseMap() {
 			super(PLUGIN_NAME);
 		}
-		
-		public Node map(Object[] vals) {
+
+		@Override
+		public Node apply(Object[] vals) {
 			Node node = new SetEnumerateNode(((Node)vals[0]).getScannerInfo());
 			addChildren(node, vals);
 			return node;
@@ -1157,8 +1158,9 @@ public class SetPlugin extends Plugin
 		public SetComprehensionParseMap() {
 			super(PLUGIN_NAME);
 		}
-		
-		public Node map(Object[] vals) {
+
+		@Override
+		public Node apply(Object[] vals) {
 			Node node = null;
 			// if there is an 'is' clause
 			if (vals[1] != null && vals[1] instanceof Object[]) {

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/set/SetPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/set/SetPlugin.java
@@ -22,8 +22,8 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.set.CompilerSetPlugin;
 import org.coreasm.engine.EngineError;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/signature/SignaturePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/signature/SignaturePlugin.java
@@ -25,8 +25,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.signature.CompilerSignaturePlugin;
 import org.coreasm.engine.CoreASMEngine.EngineMode;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/signature/SignaturePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/signature/SignaturePlugin.java
@@ -210,7 +210,8 @@ public class SignaturePlugin extends Plugin
 							pTools.getOprParser("}"),
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new EnumerationNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;
@@ -233,7 +234,8 @@ public class SignaturePlugin extends Plugin
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new UniverseNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;
@@ -257,7 +259,8 @@ public class SignaturePlugin extends Plugin
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new ASTNode(
 				            		SignaturePlugin.PLUGIN_NAME,
 				            		ASTNode.DECLARATION_CLASS,
@@ -279,7 +282,8 @@ public class SignaturePlugin extends Plugin
 					pTools.getKeywParser("static", PLUGIN_NAME),
 					pTools.getKeywParser("monitored", PLUGIN_NAME)).map(new ParseMap<Node, Node>(PLUGIN_NAME) {
 
-						public Node map(Node v) {
+						@Override
+						public Node apply(Node v) {
 							return new ASTNode(
 					        		SignaturePlugin.PLUGIN_NAME,
 					        		ASTNode.DECLARATION_CLASS,
@@ -315,7 +319,8 @@ public class SignaturePlugin extends Plugin
 						).optional()
 					}).map(new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new FunctionNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;
@@ -335,7 +340,8 @@ public class SignaturePlugin extends Plugin
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							ScannerInfo info = null;
 							if (vals[0] != null)
 								info = ((Node)((Object[])vals[0])[0]).getScannerInfo();
@@ -360,7 +366,8 @@ public class SignaturePlugin extends Plugin
 						}).map(
 						new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-							public Node map(Object[] vals) {
+							@Override
+							public Node apply(Object[] vals) {
 								Node node = new ASTNode(
 					        			SignaturePlugin.PLUGIN_NAME,
 					        			ASTNode.DECLARATION_CLASS,

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/stack/StackPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/stack/StackPlugin.java
@@ -119,7 +119,8 @@ public class StackPlugin extends Plugin implements ParserPlugin,
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new PushRuleNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;
@@ -139,7 +140,8 @@ public class StackPlugin extends Plugin implements ParserPlugin,
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new PopRuleNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/stack/StackPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/stack/StackPlugin.java
@@ -19,8 +19,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.engine.VersionInfo;
 import org.coreasm.engine.absstorage.BackgroundElement;
 import org.coreasm.engine.absstorage.FunctionElement;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/step/StepPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/step/StepPlugin.java
@@ -132,7 +132,8 @@ public class StepPlugin extends Plugin implements ParserPlugin,
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new StepRuleNode(((Node)vals[0]).getScannerInfo());
 							boolean first = true;
 							for (Object o: vals) {
@@ -165,7 +166,8 @@ public class StepPlugin extends Plugin implements ParserPlugin,
 					}).map(
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new StepBlockRuleNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/step/StepPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/step/StepPlugin.java
@@ -19,8 +19,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.engine.VersionInfo;
 import org.coreasm.engine.absstorage.BackgroundElement;
 import org.coreasm.engine.absstorage.Element;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/string/StringPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/string/StringPlugin.java
@@ -22,9 +22,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Terminals;
-import org.codehaus.jparsec.Token;
+import org.jparsec.Parser;
+import org.jparsec.Terminals;
+import org.jparsec.Token;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.string.CompilerStringPlugin;
 import org.coreasm.engine.VersionInfo;
@@ -152,7 +152,7 @@ public class StringPlugin extends Plugin
 			parsers = new HashMap<String, GrammarRule>();
 			
 			Parser<Node> stringParser = Terminals.StringLiteral.PARSER.token().map(
-					new org.codehaus.jparsec.functors.Map<Token,Node>() {
+					new org.jparsec.functors.Map<Token,Node>() {
 						@Override
 						public Node map(Token from) {
 							return new StringNode(StringElement.processEscapeCharacters(from.toString()), new ScannerInfo(from));

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/string/StringPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/string/StringPlugin.java
@@ -152,12 +152,7 @@ public class StringPlugin extends Plugin
 			parsers = new HashMap<String, GrammarRule>();
 			
 			Parser<Node> stringParser = Terminals.StringLiteral.PARSER.token().map(
-					new org.jparsec.functors.Map<Token,Node>() {
-						@Override
-						public Node map(Token from) {
-							return new StringNode(StringElement.processEscapeCharacters(from.toString()), new ScannerInfo(from));
-						}						
-					}
+					from -> new StringNode(StringElement.processEscapeCharacters(from.toString()), new ScannerInfo(from))
 			);
 			
 			refStringTermParser.set(stringParser);

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/testing/TestingPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/testing/TestingPlugin.java
@@ -65,7 +65,7 @@ public class TestingPlugin extends Plugin implements ParserPlugin {
 					}).map(
 						new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 							@Override
-							public Node map(Object[] from) {
+							public Node apply(Object[] from) {
 								Node node = new ASTNode(PLUGIN_NAME, ASTNode.EXPRESSION_CLASS, "PARAM", null, ((Node) from[0]).getScannerInfo());
 								addChildren(node, from);
 								return node;
@@ -79,7 +79,7 @@ public class TestingPlugin extends Plugin implements ParserPlugin {
 							paramkeyw,
 							pTools.getIdParser()
 					}).map(new ArrayParseMap(PLUGIN_NAME){
-						public Node map(Object[] vals){
+						public Node apply(Object[] vals){
 							Node node = new ASTNode(PLUGIN_NAME, ASTNode.RULE_CLASS, "PARAM", null, ((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;
@@ -121,7 +121,7 @@ public class TestingPlugin extends Plugin implements ParserPlugin {
 		}
 		
 		@Override
-		public Node map(Object[] vals){
+		public Node apply(Object[] vals){
 			Node node = new ASTNode(PLUGIN_NAME, ASTNode.RULE_CLASS, "TestRule", null, ((Node) vals[0]).getScannerInfo());
 			addChildren(node, vals);
 			return node;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/testing/TestingPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/testing/TestingPlugin.java
@@ -5,8 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.engine.VersionInfo;
 import org.coreasm.engine.interpreter.ASTNode;
 import org.coreasm.engine.interpreter.Node;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/tree/TreePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/tree/TreePlugin.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.engine.ControlAPI;
 import org.coreasm.engine.VersionInfo;
 import org.coreasm.engine.absstorage.BackgroundElement;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/tree/TreePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/tree/TreePlugin.java
@@ -218,7 +218,8 @@ implements ParserPlugin, InterpreterPlugin,	VocabularyExtender {
 					termParser
 			}).map(
 			new ParserTools.ArrayParseMap(PLUGIN_NAME) {
-				public Node map(Object[] vals) {
+				@Override
+				public Node apply(Object[] vals) {
 					Node node = new MakeTreeRuleNode();
 					addChildren(node, vals);
 					return node;
@@ -249,7 +250,8 @@ implements ParserPlugin, InterpreterPlugin,	VocabularyExtender {
 			}).map(
 			new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-				public Node map(Object[] vals) {
+				@Override
+				public Node apply(Object[] vals) {
 					Node node = new AddChildToRuleNode();
 					addChildren(node, vals);
 					return node;
@@ -276,7 +278,8 @@ implements ParserPlugin, InterpreterPlugin,	VocabularyExtender {
 			}).map(
 			new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-				public Node map(Object[] vals) {
+				@Override
+				public Node apply(Object[] vals) {
 					Node node = new RemoveChildFromRuleNode();
 					addChildren(node, vals);
 					return node;
@@ -303,7 +306,8 @@ implements ParserPlugin, InterpreterPlugin,	VocabularyExtender {
 			}).map(
 			new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
-				public Node map(Object[] vals) {
+				@Override
+				public Node apply(Object[] vals) {
 					Node node = new RemoveChildAtRuleNode();
 					addChildren(node, vals);
 					return node;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/turboasm/TurboASMPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/turboasm/TurboASMPlugin.java
@@ -25,8 +25,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.compiler.interfaces.CompilerPlugin;
 import org.coreasm.compiler.plugins.turboasm.CompilerTurboASMPlugin;
 import org.coreasm.engine.EngineError;

--- a/org.coreasm.engine/src/org/coreasm/engine/plugins/turboasm/TurboASMPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/engine/plugins/turboasm/TurboASMPlugin.java
@@ -201,7 +201,8 @@ public class TurboASMPlugin extends Plugin implements ParserPlugin, InterpreterP
 						ruleParser,
 					}).map(
 					new ArrayParseMap(PLUGIN_NAME) {
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new IterateRuleNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;
@@ -232,7 +233,8 @@ public class TurboASMPlugin extends Plugin implements ParserPlugin, InterpreterP
 					}).map(
 					new ArrayParseMap(PLUGIN_NAME) {
 
-						public Node map(Object[] vals) {
+						@Override
+						public Node apply(Object[] vals) {
 							Node node = new ReturnResultNode(((Node)vals[0]).getScannerInfo());
 							addChildren(node, vals);
 							return node;
@@ -289,7 +291,8 @@ public class TurboASMPlugin extends Plugin implements ParserPlugin, InterpreterP
 			Parser<Node> resultLocationParser = //Parsers.map("ResultLocation",
 						pTools.getKeywParser(RESULT_KEYWORD, PLUGIN_NAME).map(
 					new ParseMap<Node, Node>(PLUGIN_NAME) {
-						public Node map(Node v) {
+						@Override
+						public Node apply(Node v) {
 							/*
 							 *  Here we do a little bit of cheating! :-)
 							 *  We basically make 'result' act as an identifier.
@@ -589,7 +592,8 @@ public class TurboASMPlugin extends Plugin implements ParserPlugin, InterpreterP
 			super(PLUGIN_NAME);
 		}
 
-		public Node map(Object[] vals) {
+		@Override
+		public Node apply(Object[] vals) {
 			nextChildName = "cond";
 			Node node = new WhileRuleNode(((Node)vals[0]).getScannerInfo());
 			addChildren(node, vals);
@@ -614,7 +618,8 @@ public class TurboASMPlugin extends Plugin implements ParserPlugin, InterpreterP
 			super(PLUGIN_NAME);
 		}
 
-		public Node map(Object[] vals) {
+		@Override
+		public Node apply(Object[] vals) {
 			nextChildName = "lambda";
 			Node node = new LocalRuleNode(((Node)vals[0]).getScannerInfo());
 			addChildren(node, vals);
@@ -641,7 +646,8 @@ public class TurboASMPlugin extends Plugin implements ParserPlugin, InterpreterP
 			super(PLUGIN_NAME);
 		}
 
-		public Node map(Object[] vals) {
+		@Override
+		public Node apply(Object[] vals) {
 			nextChildName = "alpha";
 			Node node = new ReturnTermNode(((Node)vals[0]).getScannerInfo());
 			addChildren(node, vals);
@@ -665,8 +671,9 @@ public class TurboASMPlugin extends Plugin implements ParserPlugin, InterpreterP
 		public SeqRuleParseMap() {
 			super(PLUGIN_NAME);
 		}
-		
-		public Node map(Object[] vals) {
+
+		@Override
+		public Node apply(Object[] vals) {
 			SeqRuleNode node = new SeqRuleNode(((Node)vals[0]).getScannerInfo());
 			ArrayList<Node> nodes = new ArrayList<Node>();
 			int i = unpackChildren(nodes, vals);

--- a/org.coreasm.engine/src/org/coreasm/jasmine/plugin/JasminePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/jasmine/plugin/JasminePlugin.java
@@ -269,25 +269,22 @@ public class JasminePlugin extends Plugin implements ParserPlugin,
 			ParserTools.getInstance(capi);
 			Parser<Token> tokp = Parsers.ANY_TOKEN.token();
 			
-			basicJavaIdParser = tokp.map( new org.jparsec.functors.Map<Token,Node>() {
-				@Override
-				public Node map(Token from) {
-					if (from.value() instanceof Tokens.Fragment) {
-						Tokens.Fragment frag = (Fragment) from.value();
-						if (frag.tag() == Tokens.Tag.IDENTIFIER || frag.tag() == Tokens.Tag.RESERVED) {
-							return new ASTNode(
-								"Jasemine",
-								ASTNode.ID_CLASS,
-								"BasicJavaID",
-								from.toString(),
-								new ScannerInfo(from),
-								Node.OTHER_NODE
-							);
-						} // else...
-					} // else...
-					return null;
-				}				
-			});
+			basicJavaIdParser = tokp.map(from -> {
+                if (from.value() instanceof Fragment) {
+                    Fragment frag = (Fragment) from.value();
+                    if (frag.tag() == Tokens.Tag.IDENTIFIER || frag.tag() == Tokens.Tag.RESERVED) {
+                        return new ASTNode(
+                            "Jasemine",
+                            ASTNode.ID_CLASS,
+                            "BasicJavaID",
+                            from.toString(),
+                            new ScannerInfo(from),
+                            Node.OTHER_NODE
+                        );
+                    } // else...
+                } // else...
+                return null;
+            });
 		}
 		
 		return basicJavaIdParser;
@@ -1229,7 +1226,8 @@ public class JasminePlugin extends Plugin implements ParserPlugin,
 			super(PLUGIN_NAME);
 		}
 
-		public Node map(Object[] nodes) {
+		@Override
+		public Node apply(Object[] nodes) {
 			ASTNode node = new ASTNode(
 					PLUGIN_NAME, 
 					ASTNode.ID_CLASS, 
@@ -1368,8 +1366,9 @@ public class JasminePlugin extends Plugin implements ParserPlugin,
 		public InvokeParseMap() {
 			super(PLUGIN_NAME);
 		}
-		
-		public Node map(Object[] vals) {
+
+		@Override
+		public Node apply(Object[] vals) {
 			resultSeen = false;
 			Node node = new InvokeRuleNode(((Node)vals[0]).getScannerInfo());
 			addChildren(node, vals);
@@ -1405,8 +1404,9 @@ public class JasminePlugin extends Plugin implements ParserPlugin,
 		public StoreParseMap() {
 			super(PLUGIN_NAME);
 		}
-		
-		public Node map(Object[] nodes) {
+
+		@Override
+		public Node apply(Object[] nodes) {
 			Node node = new StoreRuleNode(((Node)nodes[0]).getScannerInfo());
 			addChildren(node, nodes);
 			return node;
@@ -1423,8 +1423,9 @@ public class JasminePlugin extends Plugin implements ParserPlugin,
 		public NativeImportParseMap() {
 			super(PLUGIN_NAME);
 		}
-		
-		public Node map(Object[] vals) {
+
+		@Override
+		public Node apply(Object[] vals) {
 			nextIsLocation = false;
 			Node node = new NativeImportRuleNode(((Node)vals[0]).getScannerInfo());
 			addChildren(node, vals);

--- a/org.coreasm.engine/src/org/coreasm/jasmine/plugin/JasminePlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/jasmine/plugin/JasminePlugin.java
@@ -33,11 +33,11 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.StringTokenizer;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
-import org.codehaus.jparsec.Token;
-import org.codehaus.jparsec.Tokens;
-import org.codehaus.jparsec.Tokens.Fragment;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
+import org.jparsec.Token;
+import org.jparsec.Tokens;
+import org.jparsec.Tokens.Fragment;
 import org.coreasm.engine.CoreASMEngine.EngineMode;
 import org.coreasm.engine.EngineError;
 import org.coreasm.engine.Specification;
@@ -269,7 +269,7 @@ public class JasminePlugin extends Plugin implements ParserPlugin,
 			ParserTools.getInstance(capi);
 			Parser<Token> tokp = Parsers.ANY_TOKEN.token();
 			
-			basicJavaIdParser = tokp.map( new org.codehaus.jparsec.functors.Map<Token,Node>() {
+			basicJavaIdParser = tokp.map( new org.jparsec.functors.Map<Token,Node>() {
 				@Override
 				public Node map(Token from) {
 					if (from.value() instanceof Tokens.Fragment) {

--- a/org.coreasm.engine/src/org/coreasm/network/plugins/graph/GraphPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/network/plugins/graph/GraphPlugin.java
@@ -305,7 +305,7 @@ public class GraphPlugin extends Plugin implements VocabularyExtender, ParserPlu
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 
 						@Override
-						public Node map(Object[] nodes) {
+						public Node apply(Object[] nodes) {
 							NewEdgeNode node = new NewEdgeNode(((Node)nodes[0]).getScannerInfo());
 							addChildren(node, nodes);
 							return node;
@@ -322,7 +322,7 @@ public class GraphPlugin extends Plugin implements VocabularyExtender, ParserPlu
 					new ParserTools.ArrayParseMap(PLUGIN_NAME) {
 					
 						@Override
-						public Node map(Object[] nodes) {
+						public Node apply(Object[] nodes) {
 							ShowGraphNode node = new ShowGraphNode(((Node)nodes[0]).getScannerInfo());
 							addChildren(node, nodes);
 							return node;

--- a/org.coreasm.engine/src/org/coreasm/network/plugins/graph/GraphPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/network/plugins/graph/GraphPlugin.java
@@ -22,8 +22,8 @@ import java.util.Set;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.engine.CoreASMEngine;
 import org.coreasm.engine.CoreASMEngine.EngineMode;
 import org.coreasm.engine.EngineException;

--- a/org.coreasm.engine/src/org/coreasm/network/plugins/signals/SignalsPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/network/plugins/signals/SignalsPlugin.java
@@ -19,8 +19,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jparsec.Parser;
-import org.codehaus.jparsec.Parsers;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
 import org.coreasm.engine.ControlAPI;
 import org.coreasm.engine.VersionInfo;
 import org.coreasm.engine.absstorage.BackgroundElement;

--- a/org.coreasm.engine/src/org/coreasm/network/plugins/signals/SignalsPlugin.java
+++ b/org.coreasm.engine/src/org/coreasm/network/plugins/signals/SignalsPlugin.java
@@ -402,8 +402,9 @@ public class SignalsPlugin extends Plugin implements ParserPlugin,
 	    public SignalRuleParseMap() {
 			super(PLUGIN_NAME);
 		}
-		
-		public Node map(Object[] v) {
+
+		@Override
+		public Node apply(Object[] v) {
 			nextChildName = "alpha";
 			ASTNode node = new SignalRuleNode(((Node)v[0]).getScannerInfo());
 
@@ -436,8 +437,9 @@ public class SignalsPlugin extends Plugin implements ParserPlugin,
 	    public OnSignalRuleParseMap() {
 			super(PLUGIN_NAME);
 		}
-		
-		public Node map(Object[] v) {
+
+		@Override
+		public Node apply(Object[] v) {
 			ASTNode node = new OnSignalRuleNode(((Node)v[0]).getScannerInfo());
 			addChildren(node, v);
 			return node;

--- a/org.coreasm.parent/pom.xml
+++ b/org.coreasm.parent/pom.xml
@@ -100,8 +100,8 @@
 			<artifactId>maven-compiler-plugin</artifactId>
 			<version>3.1</version>
 			<configuration>
-				<source>1.7</source>
-				<target>1.7</target>
+				<source>1.8</source>
+				<target>1.8</target>
 			</configuration>
 			</plugin>
 

--- a/org.coreasm.ui.carma/pom.xml
+++ b/org.coreasm.ui.carma/pom.xml
@@ -61,8 +61,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
This upgrades the jParsec dependency to 3.0. 

There are some major changes from 2.x (from https://github.com/jparsec/jparsec/releases/tag/3.0-rc1):
- Java 8 is required
- "Change package names from `org.codehaus.jparsec` to `org.jparsec`"
- "Adapt code to Java 8 features: Remove various FP-like utilities, use lambdas everywhere..."

I applied the renamed package in 6e51145, and later on in 3fd3972 I followed the deprecation warnings and made use of the new Java 8 API.

Note: I'm not using Eclipse so I haven't tested that part.